### PR TITLE
feat(upload): add artwork upload confirmation email

### DIFF
--- a/app/actions/email/artworkDetails.ts
+++ b/app/actions/email/artworkDetails.ts
@@ -1,0 +1,69 @@
+// File: app/actions/email/artworkDetails.ts
+
+"use server";
+
+import { ArtworkUploadConfirmation } from "@/emails/templates/ArtworkUploadConfirmation";
+import { getAdminSupabaseClient } from "@/utils/supabase/server-admin";
+import { render } from "@react-email/components";
+import React from "react";
+import { resend } from "./utils";
+
+export async function sendArtworkUploadConfirmationEmail(
+  email: string,
+  uploaderName: string,
+  artworkTitle: string,
+  eventSlug: string
+) {
+  const confirmationURL = `${process.env.NEXT_PUBLIC_APP_URL}/${eventSlug}`;
+  let confirmationLink: string;
+
+  try {
+    const adminSupabaseClient = await getAdminSupabaseClient();
+    const linkResponse = await adminSupabaseClient.auth.admin.generateLink({
+      type: "magiclink",
+      email: email,
+      options: {
+        data: {
+          shouldCreateUser: false,
+        },
+        redirectTo: confirmationURL,
+      },
+    });
+
+    if (linkResponse.error) {
+      console.error("Magic link generation failed:", linkResponse.error);
+      throw new Error("Failed to generate magic link");
+    }
+
+    const linkData = linkResponse.data;
+    const escapedEmail = encodeURIComponent(email);
+    confirmationLink = `${process.env.NEXT_PUBLIC_APP_URL}/api/auth/confirm?token=${linkData.properties.hashed_token}&email=${escapedEmail}&ignoreOtpExpired=true&type=magiclink&redirect_to=${confirmationURL}`;
+
+    // Send email
+    const component = React.createElement(ArtworkUploadConfirmation, {
+      confirmationUrl: confirmationLink,
+      uploaderName: uploaderName || "Creative artist",
+      artworkTitle: artworkTitle,
+    });
+    const emailResponse = await resend.emails.send({
+      from: "Creative Contact <no-reply@creativecontact.vn>",
+      to: email,
+      subject: "Confirm Your Artwork Upload",
+      react: component,
+      text: await render(component, { plainText: true }),
+    });
+
+    console.log("Artwork upload confirmation email sent:", emailResponse);
+    return {
+      success: true,
+      email: email,
+      error: null,
+    };
+  } catch (error) {
+    console.error("Error in sendArtworkUploadConfirmationEmail:", error);
+    return {
+      success: false,
+      error: error,
+    };
+  }
+}

--- a/emails/templates/ArtworkUploadConfirmation.tsx
+++ b/emails/templates/ArtworkUploadConfirmation.tsx
@@ -1,0 +1,71 @@
+// File: emails/templates/ArtworkUploadConfirmation.tsx
+
+import {
+  Body,
+  Button,
+  Container,
+  Heading,
+  Preview,
+  render,
+  Section,
+  Text
+} from "@react-email/components";
+import * as React from "react";
+import { Layout } from "../components/Layout";
+
+interface ArtworkUploadConfirmationProps {
+  confirmationUrl: string;
+  uploaderName: string;
+  artworkTitle: string;
+}
+
+export const ArtworkUploadConfirmation: React.FC<ArtworkUploadConfirmationProps> = ({
+  confirmationUrl,
+  uploaderName,
+  artworkTitle,
+}) => {
+  const previewText = `Confirm your email for Hoàn Tất Project artwork submission`;
+
+  return (
+    <Layout>
+      <Preview>{previewText}</Preview>
+      <Heading className="text-2xl font-bold text-center text-[#f27151] my-8">
+        Artwork Submitted Successfully
+      </Heading>
+      <Text className="text-base font-bold mt-6 mb-2">
+        Hello {uploaderName},
+      </Text>
+      <Text className="text-base mb-4">
+        Your artwork has been successfully submitted to the Hoàn Tất Project. Here are the details:
+      </Text>
+      <ul className="list-none pl-0">
+        <li>
+          <Text className="text-base mb-1">
+            🎨 Artwork Title: {artworkTitle}
+          </Text>
+        </li>
+        <li>
+          <Text className="text-base mb-4">
+            👤 Uploader: {uploaderName}
+          </Text>
+        </li>
+      </ul>
+      <Text className="text-base text-center mb-4">
+        Please confirm your email address by clicking the link below:
+      </Text>
+      <Section className="text-center mt-4">
+        <Button
+          className={`bg-[#f27151] text-white text-center px-6 py-3`}
+          href={confirmationUrl}
+        >
+          Confirm Email
+        </Button>
+      </Section>
+      <Text className="text-sm text-center mt-6">
+        If you did not submit this artwork, please disregard this email.
+      </Text>
+    </Layout>
+  );
+};
+
+export default ArtworkUploadConfirmation;


### PR DESCRIPTION
## Description

This PR implements the artwork upload confirmation email feature, enhancing the user experience by providing immediate feedback after successful artwork submission.

## Key Changes

1. Implemented `sendArtworkUploadConfirmationEmail` function in `app/actions/email/artworkDetails.ts`
2. Integrated email confirmation in `UploadPageClient.tsx`
3. Created `ArtworkUploadConfirmation` email template in `emails/templates/ArtworkUploadConfirmation.tsx`

## Breaking Changes

- New environment variables are required for email functionality (e.g., RESEND_API_KEY)

## Related Issues

- Closes WEB-98

## Testing Instructions

1. Set up the required environment variables for email functionality
2. Navigate to the artwork upload page and complete the submission process
3. Verify that a confirmation email is sent to the user's email address
4. Check the upload confirmation page to ensure it displays the correct email sending status

## Additional Notes

- This feature requires the Resend email service to be properly configured
- The email template design may need further refinement based on stakeholder feedback