### PR TITLE
feat(upload): add toast to upload page & improved validation

### DIFF
--- a/app/actions/user/writeUserInfo.ts
+++ b/app/actions/user/writeUserInfo.ts
@@ -16,11 +16,12 @@ export async function writeUserInfo(
     industries: IndustryType[];
     experience: ExperienceType | null;
   },
-  validate: boolean = true
+  validateProfessionalInfo: boolean = true,
+  validateUserInfo: boolean = true
 ) {
   console.log("Received professionalInfo:", professionalInfo);
   // Validate professional info
-  if (validate) {
+  if (validateProfessionalInfo) {
     if (!professionalInfo.industries || professionalInfo.industries.length === 0 ||
       !professionalInfo.experience) {
       console.error("Invalid professional info:", professionalInfo);
@@ -29,9 +30,11 @@ export async function writeUserInfo(
   }
 
   // Validate user info
-  if (!userInfo.phone || !userInfo.firstName || !userInfo.lastName) {
-    console.error("Invalid user info:", userInfo);
-    return { success: false, error: "Invalid user info" };
+  if (validateUserInfo) {
+    if (!userInfo.phone || !userInfo.firstName || !userInfo.lastName) {
+      console.error("Invalid user info:", userInfo);
+      return { success: false, error: "Invalid user info" };
+    }
   }
 
   try {

--- a/public/translations/en/eventSlug.json
+++ b/public/translations/en/eventSlug.json
@@ -15,5 +15,13 @@
     "upload": "Upload",
     "submitting": "Submitting...",
     "loading": "Loading..."
+  },
+  "UploadSuccess": {
+    "title": "Upload Success",
+    "description": "Your artwork has been uploaded successfully. The web will redirect to the confirmation page in a moment."
+  },
+  "UploadFailure": {
+    "title": "Upload Failure",
+    "description": "There was an error uploading your artwork: {{value}}. Please try again."
   }
 }

--- a/public/translations/vi/eventSlug.json
+++ b/public/translations/vi/eventSlug.json
@@ -14,5 +14,13 @@
     "submit": "Gửi",
     "submitting": "Đang gửi...",
     "loading": "Đang tải..."
+  },
+  "UploadSuccess": {
+    "title": "Tải thành công",
+    "description": "Tác phẩm của bạn đã được tải thành công. Web sẽ chuyển hướng đến trang xác nhận trong giây lát."
+  },
+  "UploadFailure": {
+    "title": "Tải thất bại",
+    "description": "Có lỗi khi tải tác phẩm của bạn: {{value}}. Vui lòng thử lại."
   }
 }


### PR DESCRIPTION
## Description

This PR enhances the upload page by adding toast notifications for success and error events, improves the validation logic in the `writeUserInfo` function, and updates the translation files with new keys for upload success and failure messages.

## Key Changes

1. Added success and error toast notifications on artwork upload.
2. Changed redirection to use `router.push` for better client-side navigation.
3. Split `validate` parameter into `validateProfessionalInfo` and `validateUserInfo` in `writeUserInfo` function.
4. Updated validation logic to use the new parameters.
5. Added new translation keys for upload success and failure messages in English and Vietnamese.

## Breaking Changes

- `writeUserInfo` function now requires two separate validation parameters: `validateProfessionalInfo` and `validateUserInfo`.

## Related Issues

- Closes WEB-103

## Testing Instructions

1. Upload an artwork and verify that a success toast notification appears.
2. Trigger an error during the upload process and verify that an error toast notification appears.
3. Check the redirection to the confirmation page and ensure it uses `router.push`.
4. Verify the validation logic in the `writeUserInfo` function with different combinations of `validateProfessionalInfo` and `validateUserInfo`.
5. Ensure the new translation keys are correctly displayed in both English and Vietnamese.

## Additional Notes

- Ensure to update any documentation or references to the `writeUserInfo` function to reflect the new parameters.