### PR TITLE
feat(upload): add confirmation link to success toast

### DIFF
--- a/app/(public)/[eventSlug]/upload/UploadPageClient.tsx
+++ b/app/(public)/[eventSlug]/upload/UploadPageClient.tsx
@@ -303,15 +303,17 @@ export default function UploadPageClient({ eventSlug, eventData, recentEvents }:
         // Update the params to include the email sending status
         params.set('emailSent', emailResult.success ? 'true' : 'false');
       }
+      const confirmedUrl = `/${eventSlug}/upload-confirmed?${params.toString()}`;
       // Show success toast
       toast.success(t("UploadSuccess.title"), {
-        description: t("UploadSuccess.description"),
+        description: t("UploadSuccess.description", { confirmedUrl }),
+        action: <a href={confirmedUrl}>{t("UploadSuccess.action")}</a>,
         duration: 5000,
       });
       // Use window.location for a full page reload and navigation
       console.debug("Redirecting to confirmation page with params", params.toString());
       // window.location.href = `/${eventSlug}/upload-confirmed?${params.toString()}`;
-      return router.push(`/${eventSlug}/upload-confirmed?${params.toString()}`);
+      return await router.push(confirmedUrl);
     } catch (error) {
       console.error("error", error);
       toast.error(t("UploadFailure.title"), {

--- a/public/translations/en/eventSlug.json
+++ b/public/translations/en/eventSlug.json
@@ -18,7 +18,8 @@
   },
   "UploadSuccess": {
     "title": "Upload Success",
-    "description": "Your artwork has been uploaded successfully. The web will redirect to the confirmation page in a moment."
+    "description": "Your artwork has been uploaded successfully. The web will redirect to the confirmation page in a moment.",
+    "action": "Go to Confirmation"
   },
   "UploadFailure": {
     "title": "Upload Failure",

--- a/public/translations/vi/eventSlug.json
+++ b/public/translations/vi/eventSlug.json
@@ -17,7 +17,8 @@
   },
   "UploadSuccess": {
     "title": "Tải thành công",
-    "description": "Tác phẩm của bạn đã được tải thành công. Web sẽ chuyển hướng đến trang xác nhận trong giây lát."
+    "description": "Tác phẩm của bạn đã được tải thành công. Web sẽ chuyển hướng đến trang xác nhận trong giây lát.",
+    "action": "Đến Trang xác nhận"
   },
   "UploadFailure": {
     "title": "Tải thất bại",


### PR DESCRIPTION
## Description

This PR updates the upload success toast to include a link to the confirmation page and adds new translation keys for the action link in both English and Vietnamese.

## Key Changes

1. Updated the success toast to include a link to the confirmation page.
2. Added a new translation key for the action link in English.
3. Added a new translation key for the action link in Vietnamese.

## Breaking Changes

- The success toast now includes a clickable link, which may affect UI behavior.

## Related Issues

- Closes #104

## Testing Instructions

1. Upload an artwork and observe the success toast.
2. Verify that the success toast includes a link to the confirmation page.
3. Check that the link redirects correctly to the confirmation page.

## Additional Notes

- Ensure that the translations for the new action link are correct in both English and Vietnamese.