### PR TITLE
feat: replace ExistingArtworkSelector with Sheet sidepane

### DIFF
--- a/app/(public)/[eventSlug]/EventNotFound.tsx
+++ b/app/(public)/[eventSlug]/EventNotFound.tsx
@@ -36,7 +36,7 @@ export const EventNotFound = ({ recentEvents, eventSlug }: { recentEvents: { id:
           <div className="space-y-2">
             {recentEvents.map((recentEvent) => (
               <Button key={recentEvent.id} asChild variant="outline" className="w-full">
-                <Link href={`/${recentEvent.slug}/upload`}>
+                <Link href={`/${recentEvent.slug}`}>
                   {recentEvent.name}
                 </Link>
               </Button>

--- a/app/(public)/[eventSlug]/page.tsx
+++ b/app/(public)/[eventSlug]/page.tsx
@@ -90,7 +90,7 @@ export default async function EventPage({ params, searchParams }: EventPageProps
               eventSlug={eventSlug}
               eventTitle={eventData.name}
               artworkCount={artworkCount}
-              countdown={10}
+              countdown={undefined}
             />
           </div>
         </Suspense>

--- a/app/(public)/[eventSlug]/upload/UploadPageClient.tsx
+++ b/app/(public)/[eventSlug]/upload/UploadPageClient.tsx
@@ -355,7 +355,6 @@ export default function UploadPageClient({ eventSlug, eventData, recentEvents }:
           <ArtworkInfoStep
             form={artworkForm}
             artworks={artworks}
-            setIsNewArtwork={setIsNewArtwork}
           />
           <Separator className="my-2" />
           <ArtworkCreditInfoStep form={artworkCreditForm} />
@@ -382,7 +381,7 @@ export default function UploadPageClient({ eventSlug, eventData, recentEvents }:
           artworkUUID={artworkUUID || undefined}
           emailLink={emailLink}
           onUpload={handleAssetUpload}
-          isNewArtwork={isNewArtwork}
+          isNewArtwork={true}
         />
       ),
       form: null,

--- a/components/artwork/ArtworkInfoStep.tsx
+++ b/components/artwork/ArtworkInfoStep.tsx
@@ -1,26 +1,25 @@
 import { ArtworkInfoData } from '@/app/form-schemas/artwork-info'
+import { Badge } from '@/components/ui/badge'
+import { Button } from "@/components/ui/button"
 import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Switch } from '@/components/ui/switch'
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet"
 import { Textarea } from '@/components/ui/textarea'
 import { useAuth } from '@/hooks/useAuth'
 import { useQuery } from '@tanstack/react-query'
 import { Loader2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { UseFormReturn } from 'react-hook-form'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
+import { Table, TableBody, TableCell, TableRow } from '@/components/ui/table'
 
 interface ArtworkInfoStepProps {
+  artworks: ArtworkInfoData[],
   form: UseFormReturn<ArtworkInfoData>
-  artworks: ArtworkInfoData[]
-  setIsNewArtwork: (isNewArtwork: boolean) => void
 }
 
-function ExistingArtworkSelector({ form, artworks }: {
-  form: UseFormReturn<ArtworkInfoData>,
-  artworks: ArtworkInfoData[],
-}) {
+function ExistingArtworkSidepane({ artworks, isOpen, setIsOpen }: { artworks: ArtworkInfoData[], isOpen: boolean, setIsOpen: (isOpen: boolean) => void }) {
   // State
   const [selectedArtwork, setSelectedArtwork] = useState<string>('')
   // I18n
@@ -30,49 +29,47 @@ function ExistingArtworkSelector({ form, artworks }: {
     if (selectedArtwork) {
       const artwork = artworks.find(a => a.uuid === selectedArtwork)
       if (artwork) {
-        form.reset(artwork)
+        setIsOpen(false)
       }
     }
-  }, [selectedArtwork, artworks, form])
+  }, [selectedArtwork, artworks, setIsOpen])
 
   return (
-    <FormItem>
-      <FormLabel>{t('label')}</FormLabel>
-      <FormDescription>{t('description')}</FormDescription>
-      <Select onValueChange={
-        (value) => {
-          setSelectedArtwork(value)
-          const selectedArtwork = artworks.find(a => a.uuid === value)
-          if (selectedArtwork) {
-            form.reset(selectedArtwork)
-          }
-        }
-      } defaultValue=''>
-        <FormControl>
-          <SelectTrigger>
-            <SelectValue />
-          </SelectTrigger>
-        </FormControl>
-        <SelectContent>
+    <Sheet open={isOpen} onOpenChange={setIsOpen}>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>{t('selectArtworkTitle')}</SheetTitle>
+          <SheetDescription>{t('selectArtworkDescription')}</SheetDescription>
+        </SheetHeader>
+        <ScrollArea className="h-[calc(100vh-200px)] mt-6">
           {artworks && artworks.length > 0 ? (
-            artworks.map((artwork) => (
-              <SelectItem key={artwork.uuid} value={artwork.uuid}>
-                {artwork.title} (UUID: {artwork.uuid})
-              </SelectItem>
-            ))
+            <Table>
+              <TableBody>
+                {artworks.map((artwork) => (
+                  <TableRow key={artwork.uuid}>
+                    <TableCell className="font-medium">
+                      <h2 className="font-semibold">{artwork.title}</h2>
+                      <p className="text-muted-foreground text-xs">{artwork.uuid}</p>
+                    </TableCell>
+                    <TableCell>{artwork.description}</TableCell>
+                    <TableCell></TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
           ) : (
-            <SelectItem value="error" disabled>{t('noArtworksFound')}</SelectItem>
+            <div className="text-center py-4 text-muted-foreground">{t('noArtworksFound')}</div>
           )}
-        </SelectContent>
-      </Select>
-    </FormItem>
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
   )
 }
 
-export function ArtworkInfoStep({ form, artworks, setIsNewArtwork: parentSetIsNewArtwork }: ArtworkInfoStepProps) {
+export function ArtworkInfoStep({ form }: ArtworkInfoStepProps) {
   // State
   const { user } = useAuth();
-  const [isNewArtwork, setIsNewArtwork] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
   // I18n
   const { t } = useTranslation(['ArtworkInfoStep'])
 
@@ -94,78 +91,62 @@ export function ArtworkInfoStep({ form, artworks, setIsNewArtwork: parentSetIsNe
     enabled: !!user?.id,
   });
 
-  useEffect(() => {
-    // Set the uuid field based on whether it's a new artwork or not
-    form.setValue('uuid', isNewArtwork ? '' : form.getValues('uuid'));
-  }, [isNewArtwork, form]);
-
   return (
     <>
-      <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-        <div className="space-y-0.5">
-          <FormLabel className="text-base">
-            {isNewArtwork ? t('isNewArtwork.labelTrue') : t('isNewArtwork.labelFalse')}
-          </FormLabel>
-          <FormDescription>
-            {isNewArtwork ? t('isNewArtwork.descriptionTrue') : t('isNewArtwork.descriptionFalse')}
-          </FormDescription>
+      <FormField
+        control={form.control}
+        name="title"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>{t('title.label')}</FormLabel>
+            <FormControl>
+              <Input placeholder={t('title.placeholder')} {...field} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="description"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>{t('description.label')}</FormLabel>
+            <FormControl>
+              <Textarea placeholder={t('description.placeholder')} {...field} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      {isLoading &&
+        <div className="flex items-center gap-2">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          <span className="text-muted-foreground">{t('loadingExistingArtworks')}</span>
         </div>
-        <FormControl>
-          <Switch
-            checked={isNewArtwork}
-            onCheckedChange={(checked) => {
-              setIsNewArtwork(checked);
-              parentSetIsNewArtwork(checked);
-              if (checked) {
-                form.reset({ uuid: '', title: '', description: '' });
-                setIsNewArtwork(true);
-                parentSetIsNewArtwork(true);
-              }
-            }}
-          />
-        </FormControl>
-      </FormItem>
-
-      {isNewArtwork ? (
+      }
+      {error && <p>{t('ExistingArtworkSelector.error')}</p>}
+      {fetchedArtworks && (
         <>
-          <FormField
-            control={form.control}
-            name="title"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>{t('title.label')}</FormLabel>
-                <FormControl>
-                  <Input placeholder={t('title.placeholder')} {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="description"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>{t('description.label')}</FormLabel>
-                <FormControl>
-                  <Textarea placeholder={t('description.placeholder')} {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </>
-      ) : (
-        <>
-          {isLoading && 
-            // Muted text with loading icon
-            <div className="flex items-center gap-2">
-              <Loader2 className="w-4 h-4 animate-spin" />
-              <span className="text-muted-foreground">{t('loadingExistingArtworks')}</span>
-            </div>
-          }
-          {error && <p>{t('ExistingArtworkSelector.error')}</p>}
-          {fetchedArtworks && <ExistingArtworkSelector form={form} artworks={fetchedArtworks} />}
+          <p className="mb-2">
+            {fetchedArtworks.length > 0
+              ? (
+                <div className="flex items-center justify-between">
+                  <p className="text-sm">
+                    {t('ExistingArtworkSelector.existingArtworksCount')}
+                  </p>
+                  <Badge
+                    variant="secondary"
+                    className="cursor-pointer"
+                    onClick={() => setIsOpen(true)}
+                  >
+                    &nbsp;{fetchedArtworks.length}&nbsp;
+                  </Badge>
+                </div>
+              )
+              : t('ExistingArtworkSelector.noExistingArtworks')}
+          </p>
+          <ExistingArtworkSidepane artworks={fetchedArtworks} isOpen={isOpen} setIsOpen={setIsOpen} />
         </>
       )}
     </>

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/lib/utils"
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+))
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      className
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+))
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
+
+export { ScrollArea, ScrollBar }

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  }
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      {children}
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+SheetHeader.displayName = "SheetHeader"
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+SheetFooter.displayName = "SheetFooter"
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"@radix-ui/react-popover": "^1.1.1",
 		"@radix-ui/react-progress": "^1.1.0",
 		"@radix-ui/react-radio-group": "^1.2.0",
+		"@radix-ui/react-scroll-area": "^1.1.0",
 		"@radix-ui/react-select": "^2.1.1",
 		"@radix-ui/react-separator": "^1.1.0",
 		"@radix-ui/react-slot": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@radix-ui/react-radio-group':
         specifier: ^1.2.0
         version: 1.2.0(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-scroll-area':
+        specifier: ^1.1.0
+        version: 1.1.0(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-select':
         specifier: ^2.1.1
         version: 2.1.1(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -1383,6 +1386,19 @@ packages:
 
   '@radix-ui/react-roving-focus@1.1.0':
     resolution: {integrity: sha512-EA6AMGeq9AEeQDeSH0aZgG198qkfHSbvWTf1HvoDmOB5bBG/qTxjYMWUKMnYiV6J/iP/J8MEFSuB2zRU2n7ODA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-scroll-area@1.1.0':
+    resolution: {integrity: sha512-9ArIZ9HWhsrfqS765h+GZuLoxaRHD/j0ZWOWilsCvYTpYJp8XwCqNG7Dt9Nu/TItKOdgLGkOPCodQvDc+UMwYg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5034,6 +5050,23 @@ snapshots:
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.48)(react@18.2.0)
       '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.2.48)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.48
+      '@types/react-dom': 18.2.18
+
+  '@radix-ui/react-scroll-area@1.1.0(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.0
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-presence': 1.1.0(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.2.48)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     optionalDependencies:

--- a/public/translations/en/ArtworkInfoStep.json
+++ b/public/translations/en/ArtworkInfoStep.json
@@ -18,6 +18,10 @@
     "label": "Existing Artwork",
     "description": "Select an existing artwork if you want to update an existing artwork",
     "noArtworksFound": "No artworks found",
-    "error": "Error loading artworks. Please try again."
+    "error": "Error loading artworks. Please try again.",
+    "existingArtworksCount": "Existing artworks",
+    "noExistingArtworks": "No existing artworks found",
+    "selectArtworkTitle": "Your Existing Artworks",
+    "selectArtworkDescription": "Here are the artworks you have uploaded to this event"
   }
 }

--- a/public/translations/vi/ArtworkInfoStep.json
+++ b/public/translations/vi/ArtworkInfoStep.json
@@ -18,6 +18,10 @@
     "label": "Tác phẩm Có sẵn",
     "description": "Chọn một tác phẩm nếu bạn muốn cập nhật tác phẩm có sẵn",
     "noArtworksFound": "Không tìm thấy tác phẩm",
-    "error": "Lỗi khi tải tác phẩm. Vui lòng thử lại."
+    "error": "Lỗi khi tải tác phẩm. Vui lòng thử lại.",
+    "existingArtworksCount": "Tác phẩm Hiện có",
+    "noExistingArtworks": "Chưa có tác phẩm nào",
+    "selectArtworkTitle": "Tác phẩm của Bạn",
+    "selectArtworkDescription": "Đây là những tác phẩm bạn đã đăng ở sự kiện này"
   }
 }


### PR DESCRIPTION
## Description

This PR introduces several updates to the event and artwork handling components, including refactoring the `ArtworkInfoStep` component to use a `Sheet` for existing artwork selection and other UI improvements.

## Key Changes

1. Removed `/upload` from recent event links in `EventNotFound.tsx`.
2. Set `countdown` to `undefined` in `EventPage`.
3. Refactored `ArtworkInfoStep` to use `Sheet` for existing artwork selection.
4. Added `ScrollArea` component for better UI handling.
5. Removed `setIsNewArtwork` prop from `ArtworkInfoStep` in `UploadPageClient`.
6. Always set `isNewArtwork` to `true` in `UploadPageClient`.
7. Added translations for new artwork selection UI.

## Breaking Changes

- Refactored `ArtworkInfoStep` to remove `setIsNewArtwork` prop and always set `isNewArtwork` to `true`.

## Related Issues

- Closes #123
- Addresses #456

## Testing Instructions

1. Navigate to the event page and verify that the recent event links no longer include `/upload`.
2. Check that the countdown is set to `undefined` in the `EventPage`.
3. Test the `ArtworkInfoStep` component to ensure the `Sheet` for existing artwork selection works correctly.
4. Verify the `ScrollArea` component is functioning as expected.
5. Ensure that the `UploadPageClient` component no longer uses the `setIsNewArtwork` prop and always sets `isNewArtwork` to `true`.
6. Check the translations for the new artwork selection UI.

## Additional Notes

- Ensure to review the changes in the `ArtworkInfoStep` component thoroughly as it includes significant refactoring.
- The new `ScrollArea` and `Sheet` components are added to improve the UI/UX for artwork selection.