### PR TITLE
fix(upload): normalize Vietnamese characters in file names

### DIFF
--- a/components/uploads/FileTable.tsx
+++ b/components/uploads/FileTable.tsx
@@ -5,14 +5,14 @@ import { useTranslation } from 'react-i18next'
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 
-import { SupabaseFile } from '@/app/types/SupabaseFile'
+import { SupabaseFile, ThumbnailSupabaseFile } from '@/app/types/SupabaseFile'
 
 interface FileTableProps {
-  files: SupabaseFile[];
+  files: ThumbnailSupabaseFile[];
   isReadonly: boolean;
   thumbnailFile: string | null;
   setThumbnailFile: (file: string | null) => void;
-  removeFile: (file: SupabaseFile) => void;
+  removeFile: (file: ThumbnailSupabaseFile) => void;
 }
 
 export const FileTable: React.FC<FileTableProps> = ({ files, isReadonly, thumbnailFile, setThumbnailFile, removeFile }) => {
@@ -34,6 +34,21 @@ export const FileTable: React.FC<FileTableProps> = ({ files, isReadonly, thumbna
     return truncatedName + ext
   }
 
+  const handleRemoveFile = (file: ThumbnailSupabaseFile) => {
+    removeFile(file);
+    if (thumbnailFile === file.name) {
+      setThumbnailFile(null);
+    }
+  }
+
+  const handleThumbnailChange = (fileName: string) => {
+    setThumbnailFile(fileName);
+    // Update the is_thumbnail property for all files
+    files.forEach(file => {
+      file.isThumbnail = file.name === fileName;
+    });
+  }
+
   return (
     <Table className="mt-4">
       <TableHeader>
@@ -49,8 +64,14 @@ export const FileTable: React.FC<FileTableProps> = ({ files, isReadonly, thumbna
             <TableCell className="text-center">
               <RadioGroup
                 className="flex items-center justify-center"
-                value={thumbnailFile || ''} onValueChange={setThumbnailFile}>
-                <RadioGroupItem value={file.name} id={`thumbnail-${index}`} disabled={isReadonly} />
+                value={thumbnailFile || ''} 
+                onValueChange={handleThumbnailChange}>
+                <RadioGroupItem 
+                  value={file.name} 
+                  id={`thumbnail-${index}`} 
+                  disabled={isReadonly}
+                  checked={file.isThumbnail} 
+                />
               </RadioGroup>
             </TableCell>
             <TableCell className="flex items-center">
@@ -65,7 +86,8 @@ export const FileTable: React.FC<FileTableProps> = ({ files, isReadonly, thumbna
                 <button
                   type="button"
                   className="text-destructive"
-                  onClick={() => removeFile(file)}
+                  onClick={() => handleRemoveFile(file)}
+                  aria-label={`Remove ${file.name}`}
                 >
                   <Trash2 className="h-4 w-4" />
                 </button>

--- a/lib/vietnamese.ts
+++ b/lib/vietnamese.ts
@@ -1,0 +1,39 @@
+// This function converts the string to lowercase, then perform the conversion
+function toLowerCaseNonAccentVietnamese(str: string): string {
+    str = str.toLowerCase();
+    str = str.replace(/à|á|ạ|ả|ã|â|ầ|ấ|ậ|ẩ|ẫ|ă|ằ|ắ|ặ|ẳ|ẵ/g, "a");
+    str = str.replace(/è|é|ẹ|ẻ|ẽ|ê|ề|ế|ệ|ể|ễ/g, "e");
+    str = str.replace(/ì|í|ị|ỉ|ĩ/g, "i");
+    str = str.replace(/ò|ó|ọ|ỏ|õ|ô|ồ|ố|ộ|ổ|ỗ|ơ|ờ|ớ|ợ|ở|ỡ/g, "o");
+    str = str.replace(/ù|ú|ụ|ủ|ũ|ư|ừ|ứ|ự|ử|ữ/g, "u");
+    str = str.replace(/ỳ|ý|ỵ|ỷ|ỹ/g, "y");
+    str = str.replace(/đ/g, "d");
+    // Some system encode vietnamese combining accent as individual utf-8 characters
+    str = str.replace(/\u0300|\u0301|\u0303|\u0309|\u0323/g, ""); // Huyền sắc hỏi ngã nặng 
+    str = str.replace(/\u02C6|\u0306|\u031B/g, ""); // Â, Ê, Ă, Ơ, Ư
+    return str;
+}
+
+// This function keeps the casing unchanged for str, then perform the conversion
+function toNonAccentVietnamese(str: string): string {
+    str = str.replace(/A|Á|À|Ả|Ã|Ạ|Â|Ấ|Ầ|Ẩ|Ẫ|Ậ|Ă|Ắ|Ằ|Ẳ|Ẵ|Ặ/g, "A");
+    str = str.replace(/à|á|ạ|ả|ã|â|ầ|ấ|ậ|ẩ|ẫ|ậ|ă|ằ|ắ|ặ|ẳ|ẵ/g, "a");
+    str = str.replace(/E|É|È|Ẽ|Ẹ|Ê|Ế|Ề|Ễ|Ệ/, "E");
+    str = str.replace(/è|é|ẹ|ẻ|ẽ|ê|ề|ế|ệ|ể|ễ/g, "e");
+    str = str.replace(/I|Í|Ì|Ĩ|Ị/g, "I");
+    str = str.replace(/ì|í|ị|ỉ|ĩ/g, "i");
+    str = str.replace(/O|Ó|Ò|Õ|Ọ|Ô|Ố|Ồ|Ỗ|Ộ|Ơ|Ớ|Ờ|Ỡ|Ợ/g, "O");
+    str = str.replace(/ò|ó|ọ|ỏ|õ|ô|ồ|ố|ộ|ổ|ỗ|ơ|ờ|ớ|ợ|ở|ỡ/g, "o");
+    str = str.replace(/U|Ú|Ù|Ũ|Ụ|Ư|Ứ|Ừ|Ữ|Ự/g, "U");
+    str = str.replace(/ù|ú|ụ|ủ|ũ|ư|ừ|ứ|ự|ử|ữ/g, "u");
+    str = str.replace(/Y|Ý|Ỳ|Ỹ|Ỵ/g, "Y");
+    str = str.replace(/ỳ|ý|ỵ|ỷ|ỹ/g, "y");
+    str = str.replace(/Đ/g, "D");
+    str = str.replace(/đ/g, "d");
+    // Some system encode vietnamese combining accent as individual utf-8 characters
+    str = str.replace(/\u0300|\u0301|\u0303|\u0309|\u0323/g, ""); // Huyền sắc hỏi ngã nặng 
+    str = str.replace(/\u02C6|\u0306|\u031B/g, ""); // Â, Ê, Ă, Ơ, Ư
+    return str;
+}
+
+export { toLowerCaseNonAccentVietnamese, toNonAccentVietnamese };


### PR DESCRIPTION
## Description

This PR normalizes Vietnamese characters in file names to ensure consistency and avoid issues related to character encoding. It includes updates to the file handling logic to use normalized file names.

## Key Changes

1. Added `toNonAccentVietnamese` function to normalize Vietnamese characters in file names.
2. Updated `FileTable` component to handle normalized file names and manage thumbnail selection.
3. Modified `media-upload` component to use normalized file names during file upload and removal.

## Breaking Changes

- File names with Vietnamese characters are now normalized. This may affect any references to these files in the codebase.

## Related Issues

- Closes WEB-115

## Testing Instructions

1. Upload files with Vietnamese characters in their names.
2. Verify that the files are correctly displayed and managed in the `FileTable` component.
3. Ensure that thumbnail selection and file removal work as expected with normalized file names.

## Additional Notes

- The `toNonAccentVietnamese` function is located in the new `lib/vietnamese.ts` file.
- Ensure that all references to file names in the codebase are updated to use normalized names if necessary.