### PR TITLE
feat(ArtworkCard): remove description paragraph from artwork display

### DIFF
--- a/components/artwork/ArtworkCard.tsx
+++ b/components/artwork/ArtworkCard.tsx
@@ -60,7 +60,6 @@ export function ArtworkCard({ eventSlug, artwork, size }: ArtworkCardProps) {
               <time dateTime={artwork.createdAt.toISOString()} className="text-sm text-primary-foreground mb-2 block">
                 {artwork.createdAt.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
               </time>
-              <p className="text-white text-sm mb-2 line-clamp-3">{artwork.description}</p>
               <div className="flex flex-wrap gap-2 mb-2">
                 <Badge className="text-xs text-primary-foreground">
                   Assets: {artwork.assets.length}


### PR DESCRIPTION
## Description

This PR removes the description paragraph from the ArtworkCard component, simplifying the artwork display.

## Key Changes

1. Removed the `<p>` element that displayed the artwork description in the ArtworkCard component.

## Breaking Changes

- The artwork description is no longer displayed in the ArtworkCard component. Any code or features relying on this description being visible will need to be updated.

## Related Issues

- Closes #[Issue number] // Please replace with the actual issue number if applicable

## Testing Instructions

1. Navigate to a page that displays artwork using the ArtworkCard component.
2. Verify that the artwork description is no longer visible.
3. Ensure that the removal of the description doesn't negatively impact the overall layout or user experience.

## Additional Notes

This change aims to streamline the artwork display, focusing on visual elements rather than textual descriptions. It may require updates to any documentation or user guides that reference the artwork description in the card view.