### PR TITLE
style(css): use CSS3 colors for compat

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,61 +4,61 @@
 
 @layer base {
 	:root {
-		--background: 0 0% 100%;
-		--foreground: 11.25 50% 6.27%;
+		--background: 0, 0%, 100%;
+		--foreground: 11.25, 50%, 6.27%;
 
-		--primary: 11.93 86.1% 63.33%;
-		--primary-foreground: 0 0% 100%;
+		--primary: 11.93, 86.1%, 63.33%;
+		--primary-foreground: 0, 0%, 100%;
 
-		--card: 0 0% 100%;
-		--card-foreground: 11.25 50% 6.27%;
+		--card: 0, 0%, 100%;
+		--card-foreground: 11.25, 50%, 6.27%;
 
-		--popover: 0 0% 100%;
-		--popover-foreground: 11.25 50% 6.27%;
+		--popover: 0, 0%, 100%;
+		--popover-foreground: 11.25, 50%, 6.27%;
 
-		--secondary: 12.5 85.71% 94.51%;
-		--secondary-foreground: 0 0% 0%;
+		--secondary: 12.5, 85.71%, 94.51%;
+		--secondary-foreground: 0, 0%, 0%;
 
-		--muted: 11.25 88.89% 96.47%;
-		--muted-foreground: 0 0% 40%;
+		--muted: 11.25, 88.89%, 96.47%;
+		--muted-foreground: 0, 0%, 40%;
 
-		--accent: 11.25 88.89% 96.47%;
-		--accent-foreground: 11.93 86.1% 63.33%;
+		--accent: 11.25, 88.89%, 96.47%;
+		--accent-foreground: 11.93, 86.1%, 63.33%;
 
-		--destructive: 0 84.2% 60.2%;
-		--destructive-foreground: 210 40% 98%;
+		--destructive: 0, 84.2%, 60.2%;
+		--destructive-foreground: 210, 40%, 98%;
 
-		--border: 0 0% 90.2%;
-		--input: 0 0% 90.2%;
-		--ring: 11.93 86.1% 63.33%;
+		--border: 0, 0%, 90.2%;
+		--input: 0, 0%, 90.2%;
+		--ring: 11.93, 86.1%, 63.33%;
 
 		--radius: 0.1rem;
 	}
 	.dark {
-		--primary: 11.93 86.1% 63.33%;
-		--primary-foreground: 0 0% 100%;
+		--primary: 11.93, 86.1%, 63.33%;
+		--primary-foreground: 0, 0%, 100%;
 
-		--card: 0 0% 0%;
-		--card-foreground: 12.5 85.71% 94.51%;
+		--card: 0, 0%, 0%;
+		--card-foreground: 12.5, 85.71%, 94.51%;
 
-		--popover: 0 0% 0%;
-		--popover-foreground: 12.5 85.71% 94.51%;
+		--popover: 0, 0%, 0%;
+		--popover-foreground: 12.5, 85.71%, 94.51%;
 
-		--secondary: 12.63 50.44% 22.16%;
-		--secondary-foreground: 0 0% 100%;
+		--secondary: 12.63, 50.44%, 22.16%;
+		--secondary-foreground: 0, 0%, 100%;
 
-		--muted: 0 0% 9.8%;
-		--muted-foreground: 0 0% 50.2%;
+		--muted: 0, 0%, 9.8%;
+		--muted-foreground: 0, 0%, 50.2%;
 
-		--accent: 12.63 50.44% 22.16%;
-		--accent-foreground: 12.5 85.71% 94.51%;
+		--accent: 12.63, 50.44%, 22.16%;
+		--accent-foreground: 12.5, 85.71%, 94.51%;
 
-		--destructive: 0 84.2% 60.2%;
-		--destructive-foreground: 210 40% 98%;
+		--destructive: 0, 84.2%, 60.2%;
+		--destructive-foreground: 210, 40%, 98%;
 
-		--border: 0 0% 14.9%;
-		--input: 0 0% 14.9%;
-		--ring: 11.93 86.1% 63.33%;
+		--border: 0, 0%, 14.9%;
+		--input: 0, 0%, 14.9%;
+		--ring: 11.93, 86.1%, 63.33%;
 
 		--radius: 0.1rem;
 	}
@@ -66,77 +66,77 @@
 	/* https://coolors.co/e4aac2-551b33-75cf54-db0058-c98e36 */
 	/* https://www.realtimecolors.com/?colors=e4aac2-551b33-75cf54-db0058-c98e36&fonts=Plus%20Jakarta%20Sans-Plus%20Jakarta%20Sans */
 	[data-theme="trungthu-archive-2024"] {
-		--background: 335 52% 88%;
-		--foreground: 325 52% 9%;
+		--background: 335, 52%, 88%;
+		--foreground: 325, 52%, 9%;
 
-		--card: 335 52% 88%;
-		--card-foreground: 325 52% 9%;
+		--card: 335, 52%, 88%;
+		--card-foreground: 325, 52%, 9%;
 
-		--popover: 335 52% 88%;
-		--popover-foreground: 325 52% 9%;
+		--popover: 335, 52%, 88%;
+		--popover-foreground: 325, 52%, 9%;
 
-		--primary: 336 100% 57%; /* #ff257c */
-		--primary-50: 334.29 100.0% 97.25%; /* #fff1f7 */
-		--primary-100: 336.67 100.0% 92.94%; /* #ffdbe9 */
-		--primary-200: 336.16 100.0% 85.69%; /* #ffb6d3 */
-		--primary-300: 335.78 100.0% 78.63%; /* #ff92be */
-		--primary-400: 336.0 100.0% 71.57%; /* #ff6ea8 */
-		--primary-500: 335.93 100.0% 64.31%; /* #ff4992 */
-		--primary-600: 336.14 100.0% 49.8%; /* #fe0065 */
-		--primary-700: 336.11 100.0% 42.35%; /* #d80056 */
-		--primary-800: 336.07 100.0% 34.9%; /* #b20047 */
-		--primary-900: 336.0 89.0% 22.45%; /* #6a062f */
-		--primary-1000: 0 51.0% 7%; /* #1c0909 */
-		--primary-foreground: 334.29 100.0% 97.25;
+		--primary: 336, 100%, 57%; /* #ff257c */
+		--primary-50: 334.29, 100.0%, 97.25%; /* #fff1f7 */
+		--primary-100: 336.67, 100.0%, 92.94%; /* #ffdbe9 */
+		--primary-200: 336.16, 100.0%, 85.69%; /* #ffb6d3 */
+		--primary-300: 335.78, 100.0%, 78.63%; /* #ff92be */
+		--primary-400: 336.0, 100.0%, 71.57%; /* #ff6ea8 */
+		--primary-500: 335.93, 100.0%, 64.31%; /* #ff4992 */
+		--primary-600: 336.14, 100.0%, 49.8%; /* #fe0065 */
+		--primary-700: 336.11, 100.0%, 42.35%; /* #d80056 */
+		--primary-800: 336.07, 100.0%, 34.9%; /* #b20047 */
+		--primary-900: 336.0, 89.0%, 22.45%; /* #6a062f */
+		--primary-1000: 0, 51.0%, 7%; /* #1c0909 */
+		--primary-foreground: 334.29, 100.0%, 97.25%;
 
-		--secondary: 356.59 92.63% 37.25%; /* #b70711 */
-		--secondary-50: 351.0 100.0% 96.08%; /* #ffebee */
-		--secondary-100: 346.67 100.0% 89.41%; /* #ffc9d5 */
-		--secondary-200: 343.15 100.0% 82.55%; /* #ffa6bf */
-		--secondary-300: 341.13 100.0% 75.69%; /* #ff83aa */
-		--secondary-400: 340.0 100.0% 68.82%; /* #ff6095 */
-		--secondary-500: 339.28 100.0% 61.96%; /* #ff3d80 */
-		--secondary-600: 338.12 100.0% 50.0%; /* #ff005d */
-		--secondary-700: 336.11 100.0% 42.35%; /* #d80056 */
-        --secondary-800: 336.07 100.0% 34.9%; /* #b20047 */
-        --secondary-900: 336.0 100.0% 27.45%; /* #8c0038 */
-        --secondary-1000: 335.88 100.0% 20.0%; /* #660029 */
-		--secondary-foreground: 346.67 100.0% 89.41%;
+		--secondary: 356.59, 92.63%, 37.25%; /* #b70711 */
+		--secondary-50: 351.0, 100.0%, 96.08%; /* #ffebee */
+		--secondary-100: 346.67, 100.0%, 89.41%; /* #ffc9d5 */
+		--secondary-200: 343.15, 100.0%, 82.55%; /* #ffa6bf */
+		--secondary-300: 341.13, 100.0%, 75.69%; /* #ff83aa */
+		--secondary-400: 340.0, 100.0%, 68.82%; /* #ff6095 */
+		--secondary-500: 339.28, 100.0%, 61.96%; /* #ff3d80 */
+		--secondary-600: 338.12, 100.0%, 50.0%; /* #ff005d */
+		--secondary-700: 336.11, 100.0%, 42.35%; /* #d80056 */
+        --secondary-800: 336.07, 100.0%, 34.9%; /* #b20047 */
+        --secondary-900: 336.0, 100.0%, 27.45%; /* #8c0038 */
+        --secondary-1000: 335.88, 100.0%, 20.0%; /* #660029 */
+		--secondary-foreground: 346.67, 100.0%, 89.41%;
 
-		--muted: 329.07 51.32 37.06%; /* #8F2E60 */
-		--muted-50: 340.0, 10.34, 94.31; /* #F2EFF0 */
-		--muted-100: 340.0, 16.67, 92.94; /* #F0EAEC */
-		--muted-200: 335.29, 32.08, 89.61; /* #EDDCE3 */
-		--muted-300: 336.92, 37.14, 86.27; /* #E9CFD9 */
-		--muted-400: 336.36, 37.08, 82.55; /* #E3C2CF */
-		--muted-500: 335.12, 36.28, 77.84; /* #DBB2C3 */
-		--muted-600: 335.29, 35.66, 71.96; /* #D19EB3 */
-		--muted-700: 334.29, 34.81, 64.51; /* #C485A0 */
-		--muted-800: 329.07, 51.32, 37.06; /* #8F2E60 */
-		--muted-900: 327.84, 62.58, 30.39; /* #7E1D51 */
-		--muted-1000: 329.69, 47.78, 39.8; /* #963566 */
-		--muted-foreground: 329 52% 55%; /* #8F2E60 */
+		--muted: 329.07, 51.32%, 37.06%; /* #8F2E60 */
+		--muted-50: 340.0, 10.34%, 94.31%; /* #F2EFF0 */
+		--muted-100: 340.0, 16.67%, 92.94%; /* #F0EAEC */
+		--muted-200: 335.29, 32.08%, 89.61%; /* #EDDCE3 */
+		--muted-300: 336.92, 37.14%, 86.27%; /* #E9CFD9 */
+		--muted-400: 336.36, 37.08%, 82.55%; /* #E3C2CF */
+		--muted-500: 335.12, 36.28%, 77.84%; /* #DBB2C3 */
+		--muted-600: 335.29, 35.66%, 71.96%; /* #D19EB3 */
+		--muted-700: 334.29, 34.81%, 64.51%; /* #C485A0 */
+		--muted-800: 329.07, 51.32%, 37.06%; /* #8F2E60 */
+		--muted-900: 327.84, 62.58%, 30.39%; /* #7E1D51 */
+		--muted-1000: 329.69, 47.78%, 39.8%; /* #963566 */
+		--muted-foreground: 329, 52%, 55%; /* #8F2E60 */
 
-		--accent: 103.9 56.16 42.94; /* #51AB30 */
-		--accent-50: 102.86 16.28 91.57; /* #e8ede6 */
-		--accent-100: 106.67 28.12 87.45; /* #dae8d6 */
-		--accent-200: 107.14 31.82 82.75; /* #cbe1c5 */
-		--accent-300: 106.83 35.04 77.06; /* #b9d9b0 */
-		--accent-400: 106.67 35.06 69.8; /* #a3cd97 */
-		--accent-500: 106.67 35.29 60.0; /* #85bd75 */
-		--accent-600: 105.44 44.21 45.69; /* #5aa841 */
-		--accent-700: 103.9 56.16 42.94; /* #51ab30 */
-		--accent-800: 104.42 50.0 40.78; /* #4f9c34 */
-		--accent-900: 103.64 100.0 21.57; /* #1e6e00 */
-		--accent-1000: 105.88 39.53 16.86; /* #223c1a */
-		--accent-foreground: 325 52% 9%;
+		--accent: 103.9, 56.16%, 42.94%; /* #51AB30 */
+		--accent-50: 102.86, 16.28%, 91.57%; /* #e8ede6 */
+		--accent-100: 106.67, 28.12%, 87.45%; /* #dae8d6 */
+		--accent-200: 107.14, 31.82%, 82.75%; /* #cbe1c5 */
+		--accent-300: 106.83, 35.04%, 77.06%; /* #b9d9b0 */
+		--accent-400: 106.67, 35.06%, 69.8%; /* #a3cd97 */
+		--accent-500: 106.67, 35.29%, 60.0%; /* #85bd75 */
+		--accent-600: 105.44, 44.21%, 45.69%; /* #5aa841 */
+		--accent-700: 103.9, 56.16%, 42.94%; /* #51ab30 */
+		--accent-800: 104.42, 50.0%, 40.78%; /* #4f9c34 */
+		--accent-900: 103.64, 100.0%, 21.57%; /* #1e6e00 */
+		--accent-1000: 105.88, 39.53%, 16.86%; /* #223c1a */
+		--accent-foreground: 325, 52%, 9%;
 
-		--destructive: 0 85% 60%;
-		--destructive-foreground: 325 52% 9%;
+		--destructive: 0, 85%, 60%;
+		--destructive-foreground: 325, 52%, 9%;
 
-		--border: 325.85 52.0% 75.49%;
-		--input: 325.85 52.0% 75.49%;
-		--ring: 87 86% 40%;
+		--border: 325.85, 52.0%, 75.49%;
+		--input: 325.85, 52.0%, 75.49%;
+		--ring: 87, 86%, 40%;
 		
 		--radius: 0.1rem;
 	  }
@@ -144,32 +144,32 @@
 	/* https://coolors.co/f3f1f2-010101-dea3a5-f86134-283bdd */
 	/* https://www.realtimecolors.com/?colors=010101-F3F1F2-F86134-283BDD-dea3a5&fonts=Plus%20Jakarta%20Sans-Plus%20Jakarta%20Sans */
 	[data-theme="early-access-2024"] {
-		--background: 330 8% 95%;
-		--foreground: 0 0% 0%;
+		--background: 330, 8%, 95%;
+		--foreground: 0, 0%, 0%;
 		
-		--card: 330 8% 95%;
-		--card-foreground: 0 0% 0%;
+		--card: 330, 8%, 95%;
+		--card-foreground: 0, 0%, 0%;
 		
-		--popover: 330 8% 95%;
-		--popover-foreground: 0 0% 0%;
+		--popover: 330, 8%, 95%;
+		--popover-foreground: 0, 0%, 0%;
 		
-		--primary: 14 93% 59%;
-		--primary-foreground: 0 0% 0%;
-		--secondary: 358 47% 75%;
-		--secondary-foreground: 0 0% 0%;
+		--primary: 14, 93%, 59%;
+		--primary-foreground: 0, 0%, 0%;
+		--secondary: 358, 47%, 75%;
+		--secondary-foreground: 0, 0%, 0%;
 		
-		--muted: 330 8% 20%;
-		--muted-foreground: 0 0% 70%;
+		--muted: 330, 8%, 20%;
+		--muted-foreground: 0, 0%, 70%;
 		
-		--accent: 234 73% 51%;
-		--accent-foreground: 330 8% 95%;
+		--accent: 234, 73%, 51%;
+		--accent-foreground: 330, 8%, 95%;
 		
-		--destructive: 0 85% 60%;
-		--destructive-foreground: 0 0% 0%;
+		--destructive: 0, 85%, 60%;
+		--destructive-foreground: 0, 0%, 0%;
 		
-		--border: 330 8% 20%;
-		--input: 330 8% 20%;
-		--ring: 234 73% 40%;
+		--border: 330, 8%, 20%;
+		--input: 330, 8%, 20%;
+		--ring: 234, 73%, 40%;
 		
 		--radius: 0.1rem;
 	}
@@ -184,66 +184,66 @@
 	}
 }
 /* Primary colors */
-.bg-primary-50 { background-color: hsl(var(--primary-50)); }
-.bg-primary-100 { background-color: hsl(var(--primary-100)); }
-.bg-primary-200 { background-color: hsl(var(--primary-200)); }
-.bg-primary-300 { background-color: hsl(var(--primary-300)); }
-.bg-primary-400 { background-color: hsl(var(--primary-400)); }
-.bg-primary-500 { background-color: hsl(var(--primary-500)); }
-.bg-primary-600 { background-color: hsl(var(--primary-600)); }
-.bg-primary-700 { background-color: hsl(var(--primary-700)); }
-.bg-primary-800 { background-color: hsl(var(--primary-800)); }
-.bg-primary-900 { background-color: hsl(var(--primary-900)); }
-.bg-primary-1000 { background-color: hsl(var(--primary-1000)); }
+.bg-primary-50 { background-color: hsla(var(--primary-50)); }
+.bg-primary-100 { background-color: hsla(var(--primary-100)); }
+.bg-primary-200 { background-color: hsla(var(--primary-200)); }
+.bg-primary-300 { background-color: hsla(var(--primary-300)); }
+.bg-primary-400 { background-color: hsla(var(--primary-400)); }
+.bg-primary-500 { background-color: hsla(var(--primary-500)); }
+.bg-primary-600 { background-color: hsla(var(--primary-600)); }
+.bg-primary-700 { background-color: hsla(var(--primary-700)); }
+.bg-primary-800 { background-color: hsla(var(--primary-800)); }
+.bg-primary-900 { background-color: hsla(var(--primary-900)); }
+.bg-primary-1000 { background-color: hsla(var(--primary-1000)); }
 
 /* Secondary colors */
-.bg-secondary-50 { background-color: hsl(var(--secondary-50)); }
-.bg-secondary-100 { background-color: hsl(var(--secondary-100)); }
-.bg-secondary-200 { background-color: hsl(var(--secondary-200)); }
-.bg-secondary-300 { background-color: hsl(var(--secondary-300)); }
-.bg-secondary-400 { background-color: hsl(var(--secondary-400)); }
-.bg-secondary-500 { background-color: hsl(var(--secondary-500)); }
-.bg-secondary-600 { background-color: hsl(var(--secondary-600)); }
-.bg-secondary-700 { background-color: hsl(var(--secondary-700)); }
-.bg-secondary-800 { background-color: hsl(var(--secondary-800)); }
-.bg-secondary-900 { background-color: hsl(var(--secondary-900)); }
-.bg-secondary-1000 { background-color: hsl(var(--secondary-1000)); }
+.bg-secondary-50 { background-color: hsla(var(--secondary-50)); }
+.bg-secondary-100 { background-color: hsla(var(--secondary-100)); }
+.bg-secondary-200 { background-color: hsla(var(--secondary-200)); }
+.bg-secondary-300 { background-color: hsla(var(--secondary-300)); }
+.bg-secondary-400 { background-color: hsla(var(--secondary-400)); }
+.bg-secondary-500 { background-color: hsla(var(--secondary-500)); }
+.bg-secondary-600 { background-color: hsla(var(--secondary-600)); }
+.bg-secondary-700 { background-color: hsla(var(--secondary-700)); }
+.bg-secondary-800 { background-color: hsla(var(--secondary-800)); }
+.bg-secondary-900 { background-color: hsla(var(--secondary-900)); }
+.bg-secondary-1000 { background-color: hsla(var(--secondary-1000)); }
 
 /* Accent colors */
-.bg-accent-50 { background-color: hsl(var(--accent-50)); }
-.bg-accent-100 { background-color: hsl(var(--accent-100)); }
-.bg-accent-200 { background-color: hsl(var(--accent-200)); }
-.bg-accent-300 { background-color: hsl(var(--accent-300)); }
-.bg-accent-400 { background-color: hsl(var(--accent-400)); }
-.bg-accent-500 { background-color: hsl(var(--accent-500)); }
-.bg-accent-600 { background-color: hsl(var(--accent-600)); }
-.bg-accent-700 { background-color: hsl(var(--accent-700)); }
-.bg-accent-800 { background-color: hsl(var(--accent-800)); }
-.bg-accent-900 { background-color: hsl(var(--accent-900)); }
-.bg-accent-1000 { background-color: hsl(var(--accent-1000)); }
+.bg-accent-50 { background-color: hsla(var(--accent-50)); }
+.bg-accent-100 { background-color: hsla(var(--accent-100)); }
+.bg-accent-200 { background-color: hsla(var(--accent-200)); }
+.bg-accent-300 { background-color: hsla(var(--accent-300)); }
+.bg-accent-400 { background-color: hsla(var(--accent-400)); }
+.bg-accent-500 { background-color: hsla(var(--accent-500)); }
+.bg-accent-600 { background-color: hsla(var(--accent-600)); }
+.bg-accent-700 { background-color: hsla(var(--accent-700)); }
+.bg-accent-800 { background-color: hsla(var(--accent-800)); }
+.bg-accent-900 { background-color: hsla(var(--accent-900)); }
+.bg-accent-1000 { background-color: hsla(var(--accent-1000)); }
 
 /* Success colors */
-.bg-success-50 { background-color: hsl(var(--success-50)); }
-.bg-success-100 { background-color: hsl(var(--success-100)); }
-.bg-success-200 { background-color: hsl(var(--success-200)); }
-.bg-success-300 { background-color: hsl(var(--success-300)); }
-.bg-success-400 { background-color: hsl(var(--success-400)); }
-.bg-success-500 { background-color: hsl(var(--success-500)); }
-.bg-success-600 { background-color: hsl(var(--success-600)); }
-.bg-success-700 { background-color: hsl(var(--success-700)); }
-.bg-success-800 { background-color: hsl(var(--success-800)); }
-.bg-success-900 { background-color: hsl(var(--success-900)); }
-.bg-success-1000 { background-color: hsl(var(--success-1000)); }
+.bg-success-50 { background-color: hsla(var(--success-50)); }
+.bg-success-100 { background-color: hsla(var(--success-100)); }
+.bg-success-200 { background-color: hsla(var(--success-200)); }
+.bg-success-300 { background-color: hsla(var(--success-300)); }
+.bg-success-400 { background-color: hsla(var(--success-400)); }
+.bg-success-500 { background-color: hsla(var(--success-500)); }
+.bg-success-600 { background-color: hsla(var(--success-600)); }
+.bg-success-700 { background-color: hsla(var(--success-700)); }
+.bg-success-800 { background-color: hsla(var(--success-800)); }
+.bg-success-900 { background-color: hsla(var(--success-900)); }
+.bg-success-1000 { background-color: hsla(var(--success-1000)); }
 
 /* Destructive colors */
-.bg-destructive-50 { background-color: hsl(var(--destructive-50)); }
-.bg-destructive-100 { background-color: hsl(var(--destructive-100)); }
-.bg-destructive-200 { background-color: hsl(var(--destructive-200)); }
-.bg-destructive-300 { background-color: hsl(var(--destructive-300)); }
-.bg-destructive-400 { background-color: hsl(var(--destructive-400)); }
-.bg-destructive-500 { background-color: hsl(var(--destructive-500)); }
-.bg-destructive-600 { background-color: hsl(var(--destructive-600)); }
-.bg-destructive-700 { background-color: hsl(var(--destructive-700)); }
-.bg-destructive-800 { background-color: hsl(var(--destructive-800)); }
-.bg-destructive-900 { background-color: hsl(var(--destructive-900)); }
-.bg-destructive-1000 { background-color: hsl(var(--destructive-1000)); }
+.bg-destructive-50 { background-color: hsla(var(--destructive-50)); }
+.bg-destructive-100 { background-color: hsla(var(--destructive-100)); }
+.bg-destructive-200 { background-color: hsla(var(--destructive-200)); }
+.bg-destructive-300 { background-color: hsla(var(--destructive-300)); }
+.bg-destructive-400 { background-color: hsla(var(--destructive-400)); }
+.bg-destructive-500 { background-color: hsla(var(--destructive-500)); }
+.bg-destructive-600 { background-color: hsla(var(--destructive-600)); }
+.bg-destructive-700 { background-color: hsla(var(--destructive-700)); }
+.bg-destructive-800 { background-color: hsla(var(--destructive-800)); }
+.bg-destructive-900 { background-color: hsla(var(--destructive-900)); }
+.bg-destructive-1000 { background-color: hsla(var(--destructive-1000)); }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -29,142 +29,142 @@ const config = {
         sans: ['var(--font-plus-jakarta-sans)', 'Plus Jakarta Sans', 'Century Gothic', 'Arial', 'Helvetica', 'sans-serif'],
       },
       colors: {
-        border: "hsl(var(--border) / <alpha-value>)",
-        input: "hsl(var(--input) / <alpha-value>)",
-        ring: "hsl(var(--ring) / <alpha-value>)",
-        background: "hsl(var(--background) / <alpha-value>)",
-        foreground: "hsl(var(--foreground) / <alpha-value>)",
+        border: "hsla(var(--border), <alpha-value>)",
+        input: "hsla(var(--input), <alpha-value>)",
+        ring: "hsla(var(--ring), <alpha-value>)",
+        background: "hsla(var(--background), <alpha-value>)",
+        foreground: "hsla(var(--foreground), <alpha-value>)",
         primary: {
-          DEFAULT: "hsl(var(--primary) / <alpha-value>)",
-          foreground: "hsl(var(--primary-foreground) / <alpha-value>)",
-          50: "hsl(var(--primary-50) / <alpha-value>)",
-          100: "hsl(var(--primary-100) / <alpha-value>)",
-          200: "hsl(var(--primary-200) / <alpha-value>)",
-          300: "hsl(var(--primary-300) / <alpha-value>)",
-          400: "hsl(var(--primary-400) / <alpha-value>)",
-          500: "hsl(var(--primary-500) / <alpha-value>)",
-          600: "hsl(var(--primary-600) / <alpha-value>)",
-          700: "hsl(var(--primary-700) / <alpha-value>)",
-          800: "hsl(var(--primary-800) / <alpha-value>)",
-          900: "hsl(var(--primary-900) / <alpha-value>)",
-          1000: "hsl(var(--primary-1000) / <alpha-value>)",
+          DEFAULT: "hsla(var(--primary), <alpha-value>)",
+          foreground: "hsla(var(--primary-foreground), <alpha-value>)",
+          50: "hsla(var(--primary-50), <alpha-value>)",
+          100: "hsla(var(--primary-100), <alpha-value>)",
+          200: "hsla(var(--primary-200), <alpha-value>)",
+          300: "hsla(var(--primary-300), <alpha-value>)",
+          400: "hsla(var(--primary-400), <alpha-value>)",
+          500: "hsla(var(--primary-500), <alpha-value>)",
+          600: "hsla(var(--primary-600), <alpha-value>)",
+          700: "hsla(var(--primary-700), <alpha-value>)",
+          800: "hsla(var(--primary-800), <alpha-value>)",
+          900: "hsla(var(--primary-900), <alpha-value>)",
+          1000: "hsla(var(--primary-1000), <alpha-value>)",
         },
         secondary: {
-          DEFAULT: "hsl(var(--secondary) / <alpha-value>)",
-          foreground: "hsl(var(--secondary-foreground) / <alpha-value>)",
-          50: "hsl(var(--secondary-50) / <alpha-value>)",
-          100: "hsl(var(--secondary-100) / <alpha-value>)",
-          200: "hsl(var(--secondary-200) / <alpha-value>)",
-          300: "hsl(var(--secondary-300) / <alpha-value>)",
-          400: "hsl(var(--secondary-400) / <alpha-value>)",
-          500: "hsl(var(--secondary-500) / <alpha-value>)",
-          600: "hsl(var(--secondary-600) / <alpha-value>)",
-          700: "hsl(var(--secondary-700) / <alpha-value>)",
-          800: "hsl(var(--secondary-800) / <alpha-value>)",
-          900: "hsl(var(--secondary-900) / <alpha-value>)",
-          1000: "hsl(var(--secondary-1000) / <alpha-value>)",
+          DEFAULT: "hsla(var(--secondary), <alpha-value>)",
+          foreground: "hsla(var(--secondary-foreground), <alpha-value>)",
+          50: "hsla(var(--secondary-50), <alpha-value>)",
+          100: "hsla(var(--secondary-100), <alpha-value>)",
+          200: "hsla(var(--secondary-200), <alpha-value>)",
+          300: "hsla(var(--secondary-300), <alpha-value>)",
+          400: "hsla(var(--secondary-400), <alpha-value>)",
+          500: "hsla(var(--secondary-500), <alpha-value>)",
+          600: "hsla(var(--secondary-600), <alpha-value>)",
+          700: "hsla(var(--secondary-700), <alpha-value>)",
+          800: "hsla(var(--secondary-800), <alpha-value>)",
+          900: "hsla(var(--secondary-900), <alpha-value>)",
+          1000: "hsla(var(--secondary-1000), <alpha-value>)",
         },
         destructive: {
-          DEFAULT: "hsl(var(--destructive) / <alpha-value>)",
-          foreground: "hsl(var(--destructive-foreground) / <alpha-value>)",
+          DEFAULT: "hsla(var(--destructive), <alpha-value>)",
+          foreground: "hsla(var(--destructive-foreground), <alpha-value>)",
         },
         muted: {
-          DEFAULT: "hsl(var(--muted) / <alpha-value>)",
-          foreground: "hsl(var(--muted-foreground) / <alpha-value>)",
+          DEFAULT: "hsla(var(--muted), <alpha-value>)",
+          foreground: "hsla(var(--muted-foreground), <alpha-value>)",
         },
         accent: {
-          DEFAULT: "hsl(var(--accent) / <alpha-value>)",
-          foreground: "hsl(var(--accent-foreground) / <alpha-value>)",
-          50: "hsl(var(--accent-50) / <alpha-value>)",
-          100: "hsl(var(--accent-100) / <alpha-value>)",
-          200: "hsl(var(--accent-200) / <alpha-value>)",
-          300: "hsl(var(--accent-300) / <alpha-value>)",
-          400: "hsl(var(--accent-400) / <alpha-value>)",
-          500: "hsl(var(--accent-500) / <alpha-value>)",
-          600: "hsl(var(--accent-600) / <alpha-value>)",
-          700: "hsl(var(--accent-700) / <alpha-value>)",
-          800: "hsl(var(--accent-800) / <alpha-value>)",
-          900: "hsl(var(--accent-900) / <alpha-value>)",
-          1000: "hsl(var(--accent-1000) / <alpha-value>)",
+          DEFAULT: "hsla(var(--accent), <alpha-value>)",
+          foreground: "hsla(var(--accent-foreground), <alpha-value>)",
+          50: "hsla(var(--accent-50), <alpha-value>)",
+          100: "hsla(var(--accent-100), <alpha-value>)",
+          200: "hsla(var(--accent-200), <alpha-value>)",
+          300: "hsla(var(--accent-300), <alpha-value>)",
+          400: "hsla(var(--accent-400), <alpha-value>)",
+          500: "hsla(var(--accent-500), <alpha-value>)",
+          600: "hsla(var(--accent-600), <alpha-value>)",
+          700: "hsla(var(--accent-700), <alpha-value>)",
+          800: "hsla(var(--accent-800), <alpha-value>)",
+          900: "hsla(var(--accent-900), <alpha-value>)",
+          1000: "hsla(var(--accent-1000), <alpha-value>)",
         },
         popover: {
-          DEFAULT: "hsl(var(--popover) / <alpha-value>)",
-          foreground: "hsl(var(--popover-foreground) / <alpha-value>)",
+          DEFAULT: "hsla(var(--popover), <alpha-value>)",
+          foreground: "hsla(var(--popover-foreground), <alpha-value>)",
         },
         card: {
-          DEFAULT: "hsl(var(--card) / <alpha-value>)",
-          foreground: "hsl(var(--card-foreground) / <alpha-value>)",
+          DEFAULT: "hsla(var(--card), <alpha-value>)",
+          foreground: "hsla(var(--card-foreground), <alpha-value>)",
         },
         'cc-rose': {
-          DEFAULT: "hsl(336.06, 100.0%, 57.25% / 1)", // #ff257c
-          50: "hsl(334.29, 100.0%, 97.25% / 1)", // #fff1f7
-          100: "hsl(336.67, 100.0%, 92.94% / 1)", // #ffdbe9
-          200: "hsl(336.16, 100.0%, 85.69% / 1)", // #ffb6d3
-          300: "hsl(335.78, 100.0%, 78.63% / 1)", // #ff92be
-          400: "hsl(336.0, 100.0%, 71.57% / 1)", // #ff6ea8
-          500: "hsl(335.93, 100.0%, 64.31% / 1)", // #ff4992
-          600: "hsl(336.14, 100.0%, 49.8% / 1)", // #fe0065
-          700: "hsl(336.11, 100.0%, 42.35% / 1)", // #d80056
-          800: "hsl(336.07, 100.0%, 34.9% / 1)", // #b20047
-          900: "hsl(336.0, 100.0%, 27.45% / 1)", // #8c0038
-          1000: "hsl(335.88, 100.0%, 20.0% / 1)", // #660029
+          DEFAULT: "hsla(336.06, 100.0%, 57.25%, 1)", // #ff257c
+          50: "hsla(334.29, 100.0%, 97.25%, 1)", // #fff1f7
+          100: "hsla(336.67, 100.0%, 92.94%, 1)", // #ffdbe9
+          200: "hsla(336.16, 100.0%, 85.69%, 1)", // #ffb6d3
+          300: "hsla(335.78, 100.0%, 78.63%, 1)", // #ff92be
+          400: "hsla(336.0, 100.0%, 71.57%, 1)", // #ff6ea8
+          500: "hsla(335.93, 100.0%, 64.31%, 1)", // #ff4992
+          600: "hsla(336.14, 100.0%, 49.8%, 1)", // #fe0065
+          700: "hsla(336.11, 100.0%, 42.35%, 1)", // #d80056
+          800: "hsla(336.07, 100.0%, 34.9%, 1)", // #b20047
+          900: "hsla(336.0, 100.0%, 27.45%, 1)", // #8c0038
+          1000: "hsla(335.88, 100.0%, 20.0%, 1)", // #660029
         },
         'cc-kelly': {
-          DEFAULT: "hsl(103.9, 56.16, 42.94)", // #51AB30
-          50: "hsl(102.86, 16.28, 91.57)", // #e8ede6
-          100: "hsl(106.67, 28.12, 87.45)", // #dae8d6
-          200: "hsl(107.14, 31.82, 82.75)", // #cbe1c5
-          300: "hsl(106.83, 35.04, 77.06)", // #b9d9b0
-          400: "hsl(106.67, 35.06, 69.8)", // #a3cd97
-          500: "hsl(106.67, 35.29, 60.0)", // #85bd75
-          600: "hsl(105.44, 44.21, 45.69)", // #5aa841
-          700: "hsl(103.9, 56.16, 42.94)", // #51ab30
-          800: "hsl(104.42, 50.0, 40.78)", // #4f9c34
-          900: "hsl(103.64, 100.0, 21.57)", // #1e6e00
-          1000: "hsl(105.88, 39.53, 16.86)", // #223c1a
+          DEFAULT: "hsla(103.9, 56.16, 42.94)", // #51AB30
+          50: "hsla(102.86, 16.28, 91.57)", // #e8ede6
+          100: "hsla(106.67, 28.12, 87.45)", // #dae8d6
+          200: "hsla(107.14, 31.82, 82.75)", // #cbe1c5
+          300: "hsla(106.83, 35.04, 77.06)", // #b9d9b0
+          400: "hsla(106.67, 35.06, 69.8)", // #a3cd97
+          500: "hsla(106.67, 35.29, 60.0)", // #85bd75
+          600: "hsla(105.44, 44.21, 45.69)", // #5aa841
+          700: "hsla(103.9, 56.16, 42.94)", // #51ab30
+          800: "hsla(104.42, 50.0, 40.78)", // #4f9c34
+          900: "hsla(103.64, 100.0, 21.57)", // #1e6e00
+          1000: "hsla(105.88, 39.53, 16.86)", // #223c1a
         },
         'cc-lime': {
-          DEFAULT: "hsl(87.11, 85.57, 61.96)", // #A6F14B
-          50: "hsl(90.0, 18.18, 91.37)", // #e9ede5
-          100: "hsl(92.73, 44.0, 85.29)", // #d8eac9
-          200: "hsl(91.7, 49.53, 79.02)", // #c8e4af
-          300: "hsl(91.82, 47.14, 72.55)", // #b7da98
-          400: "hsl(91.2, 42.37, 65.29)", // #a5cc81
-          500: "hsl(90.0, 37.84, 56.47)", // #90ba66
-          600: "hsl(88.33, 48.21, 43.92)", // #73a63a
-          700: "hsl(87.24, 70.37, 57.65)", // #9adf47
-          800: "hsl(84.75, 71.08, 48.82)", // #8cd524
-          900: "hsl(85.33, 70.31, 25.1)", // #476d13
-          1000: "hsl(89.19, 38.95, 18.63)", // #30421d
+          DEFAULT: "hsla(87.11, 85.57, 61.96)", // #A6F14B
+          50: "hsla(90.0, 18.18, 91.37)", // #e9ede5
+          100: "hsla(92.73, 44.0, 85.29)", // #d8eac9
+          200: "hsla(91.7, 49.53, 79.02)", // #c8e4af
+          300: "hsla(91.82, 47.14, 72.55)", // #b7da98
+          400: "hsla(91.2, 42.37, 65.29)", // #a5cc81
+          500: "hsla(90.0, 37.84, 56.47)", // #90ba66
+          600: "hsla(88.33, 48.21, 43.92)", // #73a63a
+          700: "hsla(87.24, 70.37, 57.65)", // #9adf47
+          800: "hsla(84.75, 71.08, 48.82)", // #8cd524
+          900: "hsla(85.33, 70.31, 25.1)", // #476d13
+          1000: "hsla(89.19, 38.95, 18.63)", // #30421d
         },
         'cc-cornell-red': {
-          DEFAULT: "hsl(356.59, 92.63%, 37.25% / 1)", // #b70711
-          50: "hsl(351.0, 100.0%, 96.08% / 1)", // #ffebee
-          100: "hsl(346.67, 100.0%, 89.41% / 1)", // #ffc9d5
-          200: "hsl(343.15, 100.0%, 82.55% / 1)", // #ffa6bf
-          300: "hsl(341.13, 100.0%, 75.69% / 1)", // #ff83aa
-          400: "hsl(340.0, 100.0%, 68.82% / 1)", // #ff6095
-          500: "hsl(339.28, 100.0%, 61.96% / 1)", // #ff3d80
-          600: "hsl(338.12, 100.0%, 50.0% / 1)", // #ff005d
-          700: "hsl(336.11, 100.0%, 42.35% / 1)", // #d80056
-          800: "hsl(336.07, 100.0%, 34.9% / 1)", // #b20047
-          900: "hsl(336.0, 100.0%, 27.45% / 1)", // #8c0038
-          1000: "hsl(335.88, 100.0%, 20.0% / 1)", // #660029
+          DEFAULT: "hsla(356.59, 92.63%, 37.25%, 1)", // #b70711
+          50: "hsla(351.0, 100.0%, 96.08%, 1)", // #ffebee
+          100: "hsla(346.67, 100.0%, 89.41%, 1)", // #ffc9d5
+          200: "hsla(343.15, 100.0%, 82.55%, 1)", // #ffa6bf
+          300: "hsla(341.13, 100.0%, 75.69%, 1)", // #ff83aa
+          400: "hsla(340.0, 100.0%, 68.82%, 1)", // #ff6095
+          500: "hsla(339.28, 100.0%, 61.96%, 1)", // #ff3d80
+          600: "hsla(338.12, 100.0%, 50.0%, 1)", // #ff005d
+          700: "hsla(336.11, 100.0%, 42.35%, 1)", // #d80056
+          800: "hsla(336.07, 100.0%, 34.9%, 1)", // #b20047
+          900: "hsla(336.0, 100.0%, 27.45%, 1)", // #8c0038
+          1000: "hsla(335.88, 100.0%, 20.0%, 1)", // #660029
         },
         'cc-fuchsia-neutral': {
-          DEFAULT: "hsl(325.0, 52.17%, 90.98% / 1)", // #f4dcea
-          100: "hsl(325.33, 52.94%, 83.33% / 1)", // #ebbed8
-          200: "hsl(325.85, 52.0%, 75.49% / 1)", // #e1a0c5
-          300: "hsl(325.81, 52.44%, 67.84% / 1)", // #d882b3
-          400: "hsl(326.6, 51.96%, 60.0% / 1)", // #ce649f
-          500: "hsl(326.88, 51.44%, 52.35% / 1)", // #c4478c
-          600: "hsl(327.97, 51.75%, 44.71% / 1)", // #ad3776
-          700: "hsl(329.07, 51.32%, 37.06% / 1)", // #8f2e60
-          800: "hsl(331.17, 51.68%, 29.22% / 1)", // #712449
-          900: "hsl(334.74, 51.35%, 21.76% / 1)", // #541b33
-          1000: "hsl(340.54, 50.68%, 14.31% / 1)", // #37121e
-          base_white: "hsl(325.0, 52.17%, 90.98% / 1)", // #f4dcea
-          base_black: "hsl(0.0, 51.35%, 7.25% / 1)", // #1C0909
+          DEFAULT: "hsla(325.0, 52.17%, 90.98%, 1)", // #f4dcea
+          100: "hsla(325.33, 52.94%, 83.33%, 1)", // #ebbed8
+          200: "hsla(325.85, 52.0%, 75.49%, 1)", // #e1a0c5
+          300: "hsla(325.81, 52.44%, 67.84%, 1)", // #d882b3
+          400: "hsla(326.6, 51.96%, 60.0%, 1)", // #ce649f
+          500: "hsla(326.88, 51.44%, 52.35%, 1)", // #c4478c
+          600: "hsla(327.97, 51.75%, 44.71%, 1)", // #ad3776
+          700: "hsla(329.07, 51.32%, 37.06%, 1)", // #8f2e60
+          800: "hsla(331.17, 51.68%, 29.22%, 1)", // #712449
+          900: "hsla(334.74, 51.35%, 21.76%, 1)", // #541b33
+          1000: "hsla(340.54, 50.68%, 14.31%, 1)", // #37121e
+          base_white: "hsla(325.0, 52.17%, 90.98%, 1)", // #f4dcea
+          base_black: "hsla(0.0, 51.35%, 7.25%, 1)", // #1C0909
         },
 
       },


### PR DESCRIPTION
## Description

This PR updates the color system in our CSS and Tailwind configuration to use the more modern `hsla()` function instead of `hsl()`. This change improves browser compatibility and allows for more flexible alpha channel manipulation.

## Key Changes

1. Updated all color definitions in `app/globals.css` from `hsl()` to `hsla()`
2. Modified `tailwind.config.ts` to use `hsla()` for all color definitions
3. Adjusted color value formatting to use commas instead of spaces as separators

## Breaking Changes

- No breaking changes expected, as this update maintains the same color values and only changes the color function used

## Related Issues

- Addresses #WEB-134

## Testing Instructions

1. Run the application and verify that all colors appear correctly
2. Test the application in different browsers to ensure compatibility
3. Check that color opacity/alpha values work as expected in various components

## Additional Notes

- This change is based on the broader browser support for `hsla()` as referenced in [Can I Use - CSS3 Colors](https://caniuse.com/css3-colors)
- The update to use commas as separators in color definitions aligns with the CSS Color Module Level 4 specification and improves readability
- This change sets the groundwork for future enhancements in color manipulation and theming