### PR TITLE
minor(video): preload metadata, for better poster

### DIFF
--- a/components/artwork/ArtworkCard.tsx
+++ b/components/artwork/ArtworkCard.tsx
@@ -45,6 +45,7 @@ export function ArtworkCard({ eventSlug, artwork, size }: ArtworkCardProps) {
             {isVideo ? (
               <video
                 src={assetUrl}
+                preload="metadata"
                 controls
                 className="w-full h-auto"
               />


### PR DESCRIPTION
## Description

This PR optimizes video loading in the ArtworkCard component by adding the `preload="metadata"` attribute to video elements.

## Key Changes

1. Added `preload="metadata"` attribute to video elements in ArtworkCard component
2. Improved initial page load performance for pages containing video artworks

## Breaking Changes

- None

## Related Issues

- Closes WEB-138

## Testing Instructions

1. Navigate to a page containing artwork with video elements
2. Observe the initial page load time and compare it to the previous version
3. Play the video and ensure it functions correctly

## Additional Notes

- The `preload="metadata"` attribute instructs the browser to load only the metadata of the video initially, rather than the entire video file. This can significantly improve page load times, especially for pages with multiple video elements.
- This change does not affect the functionality of the video playback, but optimizes the initial loading process.