### PR TITLE
minor(video): skip first .05s for better video poster

### DIFF
--- a/components/artwork/ArtworkCard.tsx
+++ b/components/artwork/ArtworkCard.tsx
@@ -44,7 +44,7 @@ export function ArtworkCard({ eventSlug, artwork, size }: ArtworkCardProps) {
           <Link href={`/${eventSlug}/artwork/${artwork.id}`}>
             {isVideo ? (
               <video
-                src={assetUrl}
+                src={`${assetUrl}#t=0.05`}
                 preload="metadata"
                 controls
                 className="w-full h-auto"


### PR DESCRIPTION
## Description

This PR optimizes video loading in the ArtworkCard component by adding a timestamp to the video source URL.

## Key Changes

1. Modified the `src` attribute of video elements to include a timestamp (`#t=0.05`)
2. Improved initial video frame display for artwork previews

## Breaking Changes

- None

## Related Issues

- Addresses WEB-139

## Testing Instructions

1. Navigate to a page with video artworks
2. Verify that video thumbnails display an actual frame from the video instead of a black screen
3. Ensure video playback still functions correctly

## Additional Notes

- Adding `#t=0.05` to the video source URL forces the browser to load a frame at 0.05 seconds, which typically results in a non-black thumbnail
- This change aims to enhance the visual appeal of video artwork previews without affecting overall performance