### PR TITLE
feat(i18n): add language switcher to EventFooter

### DIFF
--- a/app/(public)/[eventSlug]/artwork/[artworkId]/page.tsx
+++ b/app/(public)/[eventSlug]/artwork/[artworkId]/page.tsx
@@ -242,7 +242,7 @@ export default async function ArtworkPage({
         </div>
 
         {/* Footer section */}
-        <EventFooter />
+        <EventFooter lang={lang} />
       </div>
     </BackgroundDiv>
   );

--- a/app/(public)/[eventSlug]/page.tsx
+++ b/app/(public)/[eventSlug]/page.tsx
@@ -169,7 +169,7 @@ export default async function EventPage({ params, searchParams }: EventPageProps
         </main>
 
         {/* Footer section */}
-        <EventFooter />
+        <EventFooter lang={lang}/>
       </div>
     </BackgroundDiv>
   );

--- a/components/wrappers/EventFooter.tsx
+++ b/components/wrappers/EventFooter.tsx
@@ -3,14 +3,20 @@
 import React from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
+import { Separator } from "@/components/ui/separator";
+import { useTranslation } from "@/lib/i18n/init-server";
 
 interface EventFooterProps {
   className?: string;
+  lang: string;
 }
 
 export const EventFooter: React.FC<EventFooterProps> = async ({
   className,
+  lang = 'en',
 }) => {
+  const { t } = await useTranslation(lang, "common");
+
   return (
     <footer
       className={cn(
@@ -19,7 +25,21 @@ export const EventFooter: React.FC<EventFooterProps> = async ({
       )}
     >
       <div className="container mx-auto flex w-full items-center justify-between px-4 py-4 text-muted-foreground">
-        <div className="text-left">{/* Left section content */}</div>
+        <div className="text-left flex items-center">
+          <Link
+            href={`?lang=en`}
+            className={`transition-colors duration-300 hover:text-primary-foreground ${lang === 'en' ? 'text-primary font-black' : 'font-bold'}`}
+          >
+            EN
+          </Link>
+          <Separator orientation="vertical" className="mx-2 h-4" />
+          <Link
+            href={`?lang=vi`}
+            className={`transition-colors duration-300 hover:text-primary-foreground ${lang === 'vi' ? 'text-primary font-black' : 'font-bold'}`}
+          >
+            VI
+          </Link>
+        </div>
         <div className="text-center">
           © {new Date().getFullYear()} Creative Contact
         </div>


### PR DESCRIPTION
## Description

This PR adds a language switcher to the EventFooter component, allowing users to switch between English (EN) and Vietnamese (VI) languages. It also refactors the EventFooter to use the useTranslation hook for localization support.

## Key Changes

1. Added language switcher UI to EventFooter component
2. Implemented useTranslation hook in EventFooter for localization
3. Updated ArtworkPage and EventPage to pass 'lang' prop to EventFooter
4. Added Separator component from UI library for visual separation of language options

## Breaking Changes

- EventFooter component now requires a 'lang' prop to be passed

## Related Issues

- Addresses WEB-154

## Testing Instructions

1. Navigate to any page with the EventFooter (e.g., ArtworkPage or EventPage)
2. Verify that the language switcher is visible in the footer
3. Click on 'EN' and 'VI' options to switch between languages
4. Confirm that the selected language is highlighted and the URL updates accordingly
5. Verify that the rest of the page content changes language when switched

## Additional Notes

- The language switcher uses Tailwind CSS classes for styling
- The Separator component is used from the UI library to visually separate language options
- The useTranslation hook is used to support localization in the EventFooter component
- Make sure to update any other components that use EventFooter to pass the 'lang' prop