### PR TITLE
feat(profile): implement username and display name

### DIFF
--- a/app/(protected)/profile/page.tsx
+++ b/app/(protected)/profile/page.tsx
@@ -9,8 +9,8 @@ import { fetchUserData } from "@/app/api/user/helper";
 import { UserData } from "@/app/types/UserInfo";
 
 // Component imports
-import { ContactCard } from '@/components/contacts/ContactCard';
-import { EmptyContactCard } from '@/components/contacts/EmptyContactCard';
+import { ContactCard } from "@/components/contacts/ContactCard";
+import { EmptyContactCard } from "@/components/contacts/EmptyContactCard";
 
 // UI imports
 import { Badge } from "@/components/ui/badge";
@@ -36,19 +36,26 @@ import { getSocialMediaLinks } from "@/utils/social_media";
 import { TFunction } from "i18next";
 
 // Icon imports
-import { CheckCircle, Image, Mail, MapPin, Pencil, Phone, UserCircle } from 'lucide-react';
+import {
+  CheckCircle,
+  Image,
+  Mail,
+  MapPin,
+  Pencil,
+  Phone,
+  UserCircle,
+} from "lucide-react";
 
 // Next.js imports
 import { redirect } from "next/navigation";
-import { Suspense } from 'react';
+import { Suspense } from "react";
 
 // Local component import
-import PortfolioSection from './PortfolioSection';
+import PortfolioSection from "./PortfolioSection";
 import { cookies } from "next/headers";
 
 interface ProfilePageProps {
-  params: {
-  };
+  params: {};
   searchParams: {
     lang: string;
   };
@@ -79,9 +86,9 @@ async function getUserContacts(userId?: string): Promise<UserData[]> {
   const contacts = await fetchUserContacts(userId);
 
   // Map UserInfo to UserData
-  return contacts.map(contact => ({
+  return contacts.map((contact) => ({
     ...contact,
-    email: '', // Add a default empty string or fetch the actual email
+    email: "", // Add a default empty string or fetch the actual email
     isAnonymous: false, // Set a default value
     emailConfirmedAt: null, // Set a default value
   }));
@@ -99,7 +106,7 @@ function ProfileCard({
   userData,
   userSkills,
   portfolioArtworks,
-  showButtons = false
+  showButtons = false,
 }: {
   t: TFunction;
   userData: UserData;
@@ -107,25 +114,32 @@ function ProfileCard({
   portfolioArtworks: PortfolioArtworkWithDetails[];
   showButtons?: boolean;
 }) {
-  const name = userData.displayName || `${userData.firstName} ${userData.lastName}`;
+  const name =
+    userData.displayName || `${userData.firstName} ${userData.lastName}`;
+  const userName = userData.userName || "";
   const profilePictureUrl = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/profile_pictures/${userData.profilePicture}`;
   const phoneNumber = getFormattedPhoneNumber(userData);
 
   return (
     <div className="mt-6 w-full overflow-y-auto lg:mt-0 lg:w-1/3 lg:pl-6">
-      <Card className="flex flex-col h-full">
+      <Card className="flex h-full flex-col">
         <CardHeader className="flex flex-col items-center">
-          <div className="mb-4 w-24 h-24 overflow-hidden rounded-lg">
+          <div className="mb-4 h-24 w-24 overflow-hidden rounded-lg">
             <img
               src={profilePictureUrl}
               alt={`${name}'s profile`}
-              className="w-full h-full object-cover"
+              className="h-full w-full object-cover"
             />
           </div>
-          <CardTitle className="mb-2 text-2xl font-bold flex items-center">
+          <CardTitle className="mb-2 flex items-center text-2xl font-bold">
             <UserCircle className="mr-2 h-6 w-6" />
             {name}
           </CardTitle>
+          {userName && (
+            <p className="mb-2 flex items-center text-sm text-gray-500">
+              @{userName}
+            </p>
+          )}
           <div className="mb-2 flex items-center gap-2">
             <Badge variant="success" className="flex items-center">
               <CheckCircle className="mr-1 h-3 w-3" />
@@ -136,7 +150,7 @@ function ProfileCard({
               {portfolioArtworks.length} {t("artworks")}
             </Badge>
           </div>
-          <p className="mb-4 text-sm text-gray-500 flex items-center">
+          <p className="mb-4 flex items-center text-sm text-gray-500">
             <MapPin className="mr-1 h-4 w-4" />
             {userData.location}
           </p>
@@ -163,11 +177,7 @@ function ProfileCard({
                 <h3 className="mb-2 text-lg font-semibold">{t("industry")}</h3>
                 <div className="flex flex-wrap gap-2">
                   {userData.industries.map((industry) => (
-                    <Badge
-                      key={industry}
-                      variant="default"
-                      className="text-xs"
-                    >
+                    <Badge key={industry} variant="default" className="text-xs">
                       {industry}
                     </Badge>
                   ))}
@@ -176,7 +186,9 @@ function ProfileCard({
             )}
             {userData.experience && (
               <section data-section="experience">
-                <h3 className="mb-2 text-lg font-semibold">{t("experience")}</h3>
+                <h3 className="mb-2 text-lg font-semibold">
+                  {t("experience")}
+                </h3>
                 <p>{userData.experience}</p>
               </section>
             )}
@@ -227,39 +239,46 @@ function ProfileCard({
             <Separator className="my-4" />
             {userData && (
               <section data-section="social-links">
-                <h3 className="mb-2 text-lg font-semibold">{t("socialLinks")}</h3>
+                <h3 className="mb-2 text-lg font-semibold">
+                  {t("socialLinks")}
+                </h3>
                 <div className="flex space-x-4">
-                  {getSocialMediaLinks(userData).map((link, index) => (
-                    link && link.url && (
-                      <a
-                        key={index}
-                        href={link.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary hover:text-primary-600"
-                      >
-                        <link.icon className="h-6 w-6" />
-                      </a>
-                    )
-                  ))}
+                  {getSocialMediaLinks(userData).map(
+                    (link, index) =>
+                      link &&
+                      link.url && (
+                        <a
+                          key={index}
+                          href={link.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary hover:text-primary-600"
+                        >
+                          <link.icon className="h-6 w-6" />
+                        </a>
+                      ),
+                  )}
                 </div>
               </section>
             )}
           </div>
         </CardContent>
       </Card>
-    </div >
+    </div>
   );
 }
 
-export default async function ProfilePage({ params, searchParams }: ProfilePageProps) {
+export default async function ProfilePage({
+  params,
+  searchParams,
+}: ProfilePageProps) {
   // User
   const lang = searchParams.lang || "en";
   const { t } = await useTranslation(lang, "ProfilePage");
   const { user, isLoggedIn, isAnonymous } = await useServerAuth();
   // Cookies
   const cookieStore = cookies();
-  const errorMessage = cookieStore.get('error_message')?.value;
+  const errorMessage = cookieStore.get("error_message")?.value;
 
   if (!isLoggedIn || isAnonymous) {
     redirect("/login");
@@ -271,20 +290,23 @@ export default async function ProfilePage({ params, searchParams }: ProfilePageP
   if (user) {
     const [userDataResult, portfolioArtworksResult] = await Promise.allSettled([
       fetchUserData(user.id),
-      fetchUserPortfolioArtworksWithDetails(user.id)
+      fetchUserPortfolioArtworksWithDetails(user.id),
     ]);
     // Handle user data
-    if (userDataResult.status === 'fulfilled') {
+    if (userDataResult.status === "fulfilled") {
       userData = userDataResult.value;
     } else {
       console.error("Error fetching user data:", userDataResult.reason);
     }
 
     // Handle portfolio artworks
-    if (portfolioArtworksResult.status === 'fulfilled') {
+    if (portfolioArtworksResult.status === "fulfilled") {
       portfolioArtworks = portfolioArtworksResult.value;
     } else {
-      console.error("Error fetching portfolio artworks:", portfolioArtworksResult.reason);
+      console.error(
+        "Error fetching portfolio artworks:",
+        portfolioArtworksResult.reason,
+      );
     }
   }
 
@@ -309,12 +331,16 @@ export default async function ProfilePage({ params, searchParams }: ProfilePageP
                 <div className="mb-6">
                   <Tabs defaultValue="contacts">
                     <TabsList>
-                      <TabsTrigger value="contacts">{t("contacts")}</TabsTrigger>
-                      <TabsTrigger value="portfolio">{t("portfolio")}</TabsTrigger>
+                      <TabsTrigger value="contacts">
+                        {t("contacts")}
+                      </TabsTrigger>
+                      <TabsTrigger value="portfolio">
+                        {t("portfolio")}
+                      </TabsTrigger>
                     </TabsList>
 
                     <TabsContent value="contacts">
-                      <div className="grid gap-4 grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 2xl:grid-cols-4">
+                      <div className="grid grid-cols-2 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 2xl:grid-cols-4">
                         {userData && (
                           <>
                             {getUserContacts(userData.id).then((contacts) => {
@@ -341,7 +367,9 @@ export default async function ProfilePage({ params, searchParams }: ProfilePageP
                           <PortfolioSection
                             userData={userData}
                             lang={lang}
-                            existingPortfolioArtworks={portfolioArtworks as PortfolioArtworkWithDetails[]}
+                            existingPortfolioArtworks={
+                              portfolioArtworks as PortfolioArtworkWithDetails[]
+                            }
                           />
                         </Suspense>
                       )}

--- a/app/actions/user/writeUserInfo.ts
+++ b/app/actions/user/writeUserInfo.ts
@@ -13,6 +13,7 @@ export async function writeUserInfo(
     firstName: string;
     lastName: string;
     displayName?: string;
+    userName?: string;
   },
   professionalInfo: {
     industries: IndustryType[];
@@ -23,13 +24,16 @@ export async function writeUserInfo(
     facebookHandle?: string;
   },
   validateProfessionalInfo: boolean = true,
-  validateUserInfo: boolean = true
+  validateUserInfo: boolean = true,
 ) {
   console.log("Received professionalInfo:", professionalInfo);
   // Validate professional info
   if (validateProfessionalInfo) {
-    if (!professionalInfo.industries || professionalInfo.industries.length === 0 ||
-      !professionalInfo.experience) {
+    if (
+      !professionalInfo.industries ||
+      professionalInfo.industries.length === 0 ||
+      !professionalInfo.experience
+    ) {
       console.error("Invalid professional info:", professionalInfo);
       return { success: false, error: "Invalid professional info" };
     }

--- a/app/api/user/[id]/contacts/helper.ts
+++ b/app/api/user/[id]/contacts/helper.ts
@@ -1,16 +1,17 @@
 // File: app/api/user/[id]/contacts/helper.ts
 
-import { UserData } from '@/app/types/UserInfo';
-import { contacts } from '@/drizzle/schema/contact';
-import { authUsers, userInfos } from '@/drizzle/schema/user';
-import { db } from '@/lib/db';
-import { eq } from 'drizzle-orm';
+import { UserData } from "@/app/types/UserInfo";
+import { contacts } from "@/drizzle/schema/contact";
+import { authUsers, userInfos } from "@/drizzle/schema/user";
+import { db } from "@/lib/db";
+import { eq } from "drizzle-orm";
 
 export async function fetchUserContacts(userId: string): Promise<UserData[]> {
   const contactsInfo = await db
     .select({
       id: userInfos.id,
       displayName: userInfos.displayName,
+      userName: userInfos.userName,
       location: userInfos.location,
       occupation: userInfos.occupation,
       about: userInfos.about,
@@ -34,18 +35,20 @@ export async function fetchUserContacts(userId: string): Promise<UserData[]> {
     .where(eq(contacts.userId, userId));
 
   // Ensure type safety by mapping the result to UserData
-  const typeSafeContacts: UserData[] = contactsInfo.map(contact => ({
+  const typeSafeContacts: UserData[] = contactsInfo.map((contact) => ({
     ...contact,
-    firstName: contact.firstName ?? '',
-    lastName: contact.lastName ?? '',
-    email: contact.email ?? '',
+    firstName: contact.firstName ?? "",
+    lastName: contact.lastName ?? "",
+    userName: contact.userName ?? "",
+    displayName: contact.displayName ?? "",
+    email: contact.email ?? "",
     isAnonymous: contact.isAnonymous ?? false,
     emailConfirmedAt: contact.emailConfirmedAt ?? null,
     industries: contact.industries ?? [],
     experience: contact.experience ?? null,
-    phoneCountryCode: contact.phoneCountryCode ?? '84',
-    phoneNumber: contact.phoneNumber ?? '',
-    phoneCountryAlpha3: contact.phoneCountryAlpha3 ?? 'VNM'
+    phoneCountryCode: contact.phoneCountryCode ?? "84",
+    phoneNumber: contact.phoneNumber ?? "",
+    phoneCountryAlpha3: contact.phoneCountryAlpha3 ?? "VNM",
   }));
 
   return typeSafeContacts;

--- a/app/api/user/[id]/helper.ts
+++ b/app/api/user/[id]/helper.ts
@@ -1,58 +1,62 @@
 // app/api/user/[id]/helper.ts
-import { authUsers, userInfos } from '@/drizzle/schema/user';
-import { db } from '@/lib/db';
-import { eq } from 'drizzle-orm';
+import { authUsers, userInfos } from "@/drizzle/schema/user";
+import { db } from "@/lib/db";
+import { eq } from "drizzle-orm";
 
 export async function fetchUserData(userId: string) {
-    const result = await db
-      .select({
-        id: authUsers.id,
-        email: authUsers.email,
-        firstName: userInfos.firstName,
-        lastName: userInfos.lastName,
-        phoneCountryCode: userInfos.phoneCountryCode,
-        phoneNumber: userInfos.phoneNumber,
-        phoneCountryAlpha3: userInfos.phoneCountryAlpha3,
-        isAnonymous: authUsers.isAnonymous,
-        emailConfirmedAt: authUsers.emailConfirmedAt,
-        location: userInfos.location,
-        occupation: userInfos.occupation,
-        about: userInfos.about,
-        industries: userInfos.industries,
-        experience: userInfos.experience,
-        instagramHandle: userInfos.instagramHandle,
-        facebookHandle: userInfos.facebookHandle,
-        profilePicture: userInfos.profilePicture,
-      })
-      .from(authUsers)
-      .leftJoin(userInfos, eq(authUsers.id, userInfos.id))
-      .where(eq(authUsers.id, userId))
-      .limit(1);
-  
-    if (result.length === 0) {
-      return null;
-    }
-  
-    const userData = result[0];
-  
-    // Transform the data to match the UserData interface
-    return {
-      id: userData.id,
-      email: userData.email || '',
-      firstName: userData.firstName || '',
-      lastName: userData.lastName || '',
-      phoneCountryCode: userData.phoneCountryCode || '84',
-      phoneNumber: userData.phoneNumber || '',
-      phoneCountryAlpha3: userData.phoneCountryAlpha3 || 'VNM',
-      isAnonymous: userData.isAnonymous,
-      emailConfirmedAt: userData.emailConfirmedAt,
-      location: userData.location || '',
-      occupation: userData.occupation || '',
-      about: userData.about || '',
-      industries: userData.industries || [],
-      experience: userData.experience || '',
-      instagramHandle: userData.instagramHandle,
-      facebookHandle: userData.facebookHandle,
-      profilePicture: userData.profilePicture,
-    };
+  const result = await db
+    .select({
+      id: authUsers.id,
+      email: authUsers.email,
+      firstName: userInfos.firstName,
+      lastName: userInfos.lastName,
+      userName: userInfos.userName,
+      displayName: userInfos.displayName,
+      phoneCountryCode: userInfos.phoneCountryCode,
+      phoneNumber: userInfos.phoneNumber,
+      phoneCountryAlpha3: userInfos.phoneCountryAlpha3,
+      isAnonymous: authUsers.isAnonymous,
+      emailConfirmedAt: authUsers.emailConfirmedAt,
+      location: userInfos.location,
+      occupation: userInfos.occupation,
+      about: userInfos.about,
+      industries: userInfos.industries,
+      experience: userInfos.experience,
+      instagramHandle: userInfos.instagramHandle,
+      facebookHandle: userInfos.facebookHandle,
+      profilePicture: userInfos.profilePicture,
+    })
+    .from(authUsers)
+    .leftJoin(userInfos, eq(authUsers.id, userInfos.id))
+    .where(eq(authUsers.id, userId))
+    .limit(1);
+
+  if (result.length === 0) {
+    return null;
   }
+
+  const userData = result[0];
+
+  // Transform the data to match the UserData interface
+  return {
+    id: userData.id,
+    email: userData.email || "",
+    firstName: userData.firstName || "",
+    lastName: userData.lastName || "",
+    userName: userData.userName || "",
+    displayName: userData.displayName || "",
+    phoneCountryCode: userData.phoneCountryCode || "84",
+    phoneNumber: userData.phoneNumber || "",
+    phoneCountryAlpha3: userData.phoneCountryAlpha3 || "VNM",
+    isAnonymous: userData.isAnonymous,
+    emailConfirmedAt: userData.emailConfirmedAt,
+    location: userData.location || "",
+    occupation: userData.occupation || "",
+    about: userData.about || "",
+    industries: userData.industries || [],
+    experience: userData.experience || "",
+    instagramHandle: userData.instagramHandle,
+    facebookHandle: userData.facebookHandle,
+    profilePicture: userData.profilePicture,
+  };
+}

--- a/app/form-schemas/contact-info.ts
+++ b/app/form-schemas/contact-info.ts
@@ -4,6 +4,8 @@ export const contactInfoSchema = z.object({
   email: z.string().email("Invalid email address"),
   firstName: z.string().min(3, "First name must be at least 3 characters"),
   lastName: z.string().min(3, "Last name must be at least 3 characters"),
+  userName: z.string().optional(),
+  displayName: z.string().optional(),
   phoneCountryCode: z.string().default("84"),
   phoneNumber: z.string().refine((value) => /^\d{10}$/.test(value), {
     message: "Phone number must be 10 digits",
@@ -14,4 +16,4 @@ export const contactInfoSchema = z.object({
   facebookHandle: z.string().optional(),
 });
 
-export type ContactInfoData = z.infer<typeof contactInfoSchema>
+export type ContactInfoData = z.infer<typeof contactInfoSchema>;

--- a/components/profile/BasicInfoSection.tsx
+++ b/components/profile/BasicInfoSection.tsx
@@ -81,6 +81,15 @@ export function BasicInfoSection({
           </div>
         </div>
         <div>
+          <Label htmlFor="userName">{t("BasicInfoSection.userName")}</Label>
+          <Input
+            id="userName"
+            value={userName}
+            onChange={(e) => setUserName(e.target.value)}
+            className="max-w-md"
+          />
+        </div>
+        <div>
           <Label htmlFor="displayName">
             {t("BasicInfoSection.displayName")}
           </Label>

--- a/components/profile/BasicInfoSection.tsx
+++ b/components/profile/BasicInfoSection.tsx
@@ -7,75 +7,92 @@ import { Label } from "@/components/ui/label";
 import { MapPin } from "lucide-react";
 import { useFormState } from "@/app/(protected)/profile/edit/FormStateNav";
 import { useEffect, useState } from "react";
-import { useTranslation } from '@/lib/i18n/init-client'
+import { useTranslation } from "@/lib/i18n/init-client";
 
 interface BasicInfoSectionProps {
   userData: UserData;
   lang?: string;
 }
 
-export function BasicInfoSection({ userData, lang = "en" }: BasicInfoSectionProps) {
+export function BasicInfoSection({
+  userData,
+  lang = "en",
+}: BasicInfoSectionProps) {
   const { t } = useTranslation(lang, "ProfilePage");
-  const [firstName, setFirstName] = useState(userData.firstName || '');
-  const [lastName, setLastName] = useState(userData.lastName || '');
-  const [displayName, setDisplayName] = useState(userData.displayName || '');
-  const [location, setLocation] = useState(userData.location || '');
+  const [firstName, setFirstName] = useState(userData.firstName || "");
+  const [lastName, setLastName] = useState(userData.lastName || "");
+  const [userName, setUserName] = useState(userData.userName || "");
+  const [displayName, setDisplayName] = useState(userData.displayName || "");
+  const [location, setLocation] = useState(userData.location || "");
   const { setFieldDirty, setFormData } = useFormState();
 
   useEffect(() => {
-    const isDirty = 
-      firstName !== (userData.firstName || '') ||
-      lastName !== (userData.lastName || '') ||
-      displayName !== (userData.displayName || '') ||
-      location !== (userData.location || '');
+    const isDirty =
+      firstName !== (userData.firstName || "") ||
+      lastName !== (userData.lastName || "") ||
+      userName !== (userData.userName || "") ||
+      displayName !== (userData.displayName || "") ||
+      location !== (userData.location || "");
 
-    setFieldDirty('basic', isDirty);
+    setFieldDirty("basic", isDirty);
     // Always set form data, not just when dirty
-    setFormData('basic', {
+    setFormData("basic", {
       firstName,
       lastName,
+      userName,
       displayName,
-      location
+      location,
     });
-  }, [firstName, lastName, displayName, location, userData, setFieldDirty, setFormData]);
+  }, [
+    firstName,
+    lastName,
+    userName,
+    displayName,
+    location,
+    userData,
+    setFieldDirty,
+    setFormData,
+  ]);
 
   return (
     <Card id="basic">
       <CardHeader>
-        <CardTitle>{t('BasicInfoSection.basicInfo')}</CardTitle>
+        <CardTitle>{t("BasicInfoSection.basicInfo")}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <Label htmlFor="firstName">{t('BasicInfoSection.firstName')}</Label>
-            <Input 
-              id="firstName" 
+            <Label htmlFor="firstName">{t("BasicInfoSection.firstName")}</Label>
+            <Input
+              id="firstName"
               value={firstName}
               onChange={(e) => setFirstName(e.target.value)}
-              className="max-w-md" 
+              className="max-w-md"
             />
           </div>
           <div>
-            <Label htmlFor="lastName">{t('BasicInfoSection.lastName')}</Label>
-            <Input 
-              id="lastName" 
+            <Label htmlFor="lastName">{t("BasicInfoSection.lastName")}</Label>
+            <Input
+              id="lastName"
               value={lastName}
               onChange={(e) => setLastName(e.target.value)}
-              className="max-w-md" 
+              className="max-w-md"
             />
           </div>
         </div>
         <div>
-          <Label htmlFor="displayName">{t('BasicInfoSection.displayName')}</Label>
-          <Input 
-            id="displayName" 
+          <Label htmlFor="displayName">
+            {t("BasicInfoSection.displayName")}
+          </Label>
+          <Input
+            id="displayName"
             value={displayName}
             onChange={(e) => setDisplayName(e.target.value)}
-            className="max-w-md" 
+            className="max-w-md"
           />
         </div>
         <div>
-          <Label htmlFor="location">{t('BasicInfoSection.location')}</Label>
+          <Label htmlFor="location">{t("BasicInfoSection.location")}</Label>
           <div className="relative max-w-md">
             <Input
               id="location"
@@ -83,7 +100,7 @@ export function BasicInfoSection({ userData, lang = "en" }: BasicInfoSectionProp
               disabled
               onChange={(e) => setLocation(e.target.value)}
             />
-            <MapPin className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <MapPin className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           </div>
         </div>
       </CardContent>

--- a/drizzle/schema/user.ts
+++ b/drizzle/schema/user.ts
@@ -6,9 +6,8 @@ import {
   pgTable,
   text,
   timestamp,
-  uuid
+  uuid,
 } from "drizzle-orm/pg-core";
-
 
 // Partial schema for auth.users
 export const authSchema = pgSchema("auth");
@@ -38,75 +37,84 @@ Foreign-key constraints:
 Policies (row security enabled): (none)
 */
 export const industries = [
-  'Advertising',
-  'Architecture',
-  'Arts and Crafts',
-  'Design',
-  'Fashion',
-  'Film, Video, and Photography',
-  'Music',
-  'Performing Arts',
-  'Publishing',
-  'Software and Interactive',
-  'Television and Radio',
-  'Visual Arts',
-  'Other'
+  "Advertising",
+  "Architecture",
+  "Arts and Crafts",
+  "Design",
+  "Fashion",
+  "Film, Video, and Photography",
+  "Music",
+  "Performing Arts",
+  "Publishing",
+  "Software and Interactive",
+  "Television and Radio",
+  "Visual Arts",
+  "Other",
 ] as const;
 export const experienceLevels = [
-  'Entry',
-  'Junior',
-  'Mid-level',
-  'Senior',
-  'Manager',
-  'C-level'
+  "Entry",
+  "Junior",
+  "Mid-level",
+  "Senior",
+  "Manager",
+  "C-level",
 ] as const;
-export const industryEnum = pgEnum('industry', industries);
-export const experienceEnum = pgEnum('experience_level', experienceLevels);
-export const userInfos = pgTable('user_infos', {
-  id: uuid('id').primaryKey().references(() => authUsers.id),
-  firstName: text('first_name'),
-  lastName: text('last_name'),
-  displayName: text('display_name'),
-  phoneCountryCode: text('phone_country_code').default('84'),
-  phoneNumber: text('phone_number'),
-  phoneCountryAlpha3: text('phone_country_alpha3').default('VNM'),
-  location: text('location'),
-  occupation: text('occupation'),
-  about: text('about'),
-  industries: industryEnum('industries').array(),
-  experience: experienceEnum('experience'),
-  profilePicture: text('profile_picture'),
-  instagramHandle: text('instagram_handle'),
-  facebookHandle: text('facebook_handle'),
+export const industryEnum = pgEnum("industry", industries);
+export const experienceEnum = pgEnum("experience_level", experienceLevels);
+export const userInfos = pgTable("user_infos", {
+  id: uuid("id")
+    .primaryKey()
+    .references(() => authUsers.id),
+  firstName: text("first_name"),
+  lastName: text("last_name"),
+  userName: text("user_name"),
+  displayName: text("display_name"),
+  phoneCountryCode: text("phone_country_code").default("84"),
+  phoneNumber: text("phone_number"),
+  phoneCountryAlpha3: text("phone_country_alpha3").default("VNM"),
+  location: text("location"),
+  occupation: text("occupation"),
+  about: text("about"),
+  industries: industryEnum("industries").array(),
+  experience: experienceEnum("experience"),
+  profilePicture: text("profile_picture"),
+  instagramHandle: text("instagram_handle"),
+  facebookHandle: text("facebook_handle"),
 });
 
 // TypeScript types for use in your application
-export type IndustryType = typeof industries[number];
-export type ExperienceType = typeof experienceLevels[number];
+export type IndustryType = (typeof industries)[number];
+export type ExperienceType = (typeof experienceLevels)[number];
 export type UserInfo = InferSelectModel<typeof userInfos>;
 
 // Mappers
 export const industriesMapper = [
-  { value: 'Advertising' as const, label: 'Advertising' },
-  { value: 'Architecture' as const, label: 'Architecture' },
-  { value: 'Arts and Crafts' as const, label: 'Arts and Crafts' },
-  { value: 'Design' as const, label: 'Design' },
-  { value: 'Fashion' as const, label: 'Fashion' },
-  { value: 'Film, Video, and Photography' as const, label: 'Film, Video, and Photography' },
-  { value: 'Music' as const, label: 'Music' },
-  { value: 'Performing Arts' as const, label: 'Performing Arts' },
-  { value: 'Publishing' as const, label: 'Publishing' },
-  { value: 'Software and Interactive' as const, label: 'Software and Interactive' },
-  { value: 'Television and Radio' as const, label: 'Television and Radio' },
-  { value: 'Visual Arts' as const, label: 'Visual Arts' },
-  { value: 'Other' as const, label: 'Other' }
-] as const
+  { value: "Advertising" as const, label: "Advertising" },
+  { value: "Architecture" as const, label: "Architecture" },
+  { value: "Arts and Crafts" as const, label: "Arts and Crafts" },
+  { value: "Design" as const, label: "Design" },
+  { value: "Fashion" as const, label: "Fashion" },
+  {
+    value: "Film, Video, and Photography" as const,
+    label: "Film, Video, and Photography",
+  },
+  { value: "Music" as const, label: "Music" },
+  { value: "Performing Arts" as const, label: "Performing Arts" },
+  { value: "Publishing" as const, label: "Publishing" },
+  {
+    value: "Software and Interactive" as const,
+    label: "Software and Interactive",
+  },
+  { value: "Television and Radio" as const, label: "Television and Radio" },
+  { value: "Visual Arts" as const, label: "Visual Arts" },
+  { value: "Other" as const, label: "Other" },
+] as const;
 
 export const experienceLevelsMapper = [
-  { value: 'Entry' as const, label: 'Entry' },
-  { value: 'Junior' as const, label: 'Junior' },
-  { value: 'Mid-level' as const, label: 'Mid-level' },
-  { value: 'Senior' as const, label: 'Senior' },
-  { value: 'Manager' as const, label: 'Manager' },
-  { value: 'C-level' as const, label: 'C-level' }
-] as const
+  { value: "Entry" as const, label: "Entry" },
+  { value: "Junior" as const, label: "Junior" },
+  { value: "Mid-level" as const, label: "Mid-level" },
+  { value: "Senior" as const, label: "Senior" },
+  { value: "Manager" as const, label: "Manager" },
+  { value: "C-level" as const, label: "C-level" },
+] as const;

--- a/public/translations/en/ProfilePage.json
+++ b/public/translations/en/ProfilePage.json
@@ -1,58 +1,59 @@
 {
-    "navigation": {
-        "editProfile": "Edit Profile",
-        "editPortfolio": "Edit Portfolio",
-        "basicInfo": "Basic Info", 
-        "about": "About",
-        "professional": "Professional",
-        "contact": "Contact",
-        "portfolio": "Portfolio",
-        "saveChanges": "Save Changes",
-        "saveChangesWithCount": "Save Changes ({{count}} changes)",
-        "saving": "Saving...",
-        "backToProfile": "Back to Profile",
-        "discardChanges": "Discard Changes",
-        "discardChangesDescription": "Do you want to discard {{count}} changes? If yes, your edits won't be effective.",
-        "cancel": "Cancel"
-    },
-    "BasicInfoSection": {
-        "basicInfo": "Basic Info",
-        "firstName": "First Name",
-        "lastName": "Last Name", 
-        "displayName": "Display Name",
-        "location": "Location"
-    },
-    "AboutSection": {
-        "about": "About",
-        "placeholder": "Tell us about yourself..."
-    },
-    "ContactSection": {
-        "contact": "Contact",
-        "email": "Email",
-        "phone": "Phone",
-        "socialLinks": "Social Links",
-        "instagram": "Instagram",
-        "facebook": "Facebook"
-    },
-    "ProfessionalSection": {
-        "professional": "Professional",
-        "currentIndustries": "Current Industries",
-        "experience": "Experience",
-        "select": "Select Industry",
-        "search": "Search Industries",
-        "noExperienceFound": "No Experience Found"
-    },
-    "contacts": "Contacts",
-    "activity": "Activity", 
-    "settings": "Settings",
-    "openToCollab": "Open to Collaborations",
-    "edit": "Edit",
-    "portfolio": "Portfolio",
+  "navigation": {
+    "editProfile": "Edit Profile",
+    "editPortfolio": "Edit Portfolio",
+    "basicInfo": "Basic Info",
     "about": "About",
-    "industry": "Industry",
-    "experience": "Experience",
-    "skills": "Skills",
+    "professional": "Professional",
     "contact": "Contact",
+    "portfolio": "Portfolio",
+    "saveChanges": "Save Changes",
+    "saveChangesWithCount": "Save Changes ({{count}} changes)",
+    "saving": "Saving...",
+    "backToProfile": "Back to Profile",
+    "discardChanges": "Discard Changes",
+    "discardChangesDescription": "Do you want to discard {{count}} changes? If yes, your edits won't be effective.",
+    "cancel": "Cancel"
+  },
+  "BasicInfoSection": {
+    "basicInfo": "Basic Info",
+    "firstName": "First Name",
+    "lastName": "Last Name",
+    "userName": "User Name",
+    "displayName": "Display Name",
+    "location": "Location"
+  },
+  "AboutSection": {
+    "about": "About",
+    "placeholder": "Tell us about yourself..."
+  },
+  "ContactSection": {
+    "contact": "Contact",
+    "email": "Email",
+    "phone": "Phone",
     "socialLinks": "Social Links",
-    "seeMore": "See More"
+    "instagram": "Instagram",
+    "facebook": "Facebook"
+  },
+  "ProfessionalSection": {
+    "professional": "Professional",
+    "currentIndustries": "Current Industries",
+    "experience": "Experience",
+    "select": "Select Industry",
+    "search": "Search Industries",
+    "noExperienceFound": "No Experience Found"
+  },
+  "contacts": "Contacts",
+  "activity": "Activity",
+  "settings": "Settings",
+  "openToCollab": "Open to Collaborations",
+  "edit": "Edit",
+  "portfolio": "Portfolio",
+  "about": "About",
+  "industry": "Industry",
+  "experience": "Experience",
+  "skills": "Skills",
+  "contact": "Contact",
+  "socialLinks": "Social Links",
+  "seeMore": "See More"
 }

--- a/public/translations/vi/ProfilePage.json
+++ b/public/translations/vi/ProfilePage.json
@@ -1,58 +1,59 @@
 {
-    "navigation": {
-        "editProfile": "Chỉnh sửa Hồ sơ",
-        "editPortfolio": "Chỉnh sửa Portfolio",
-        "basicInfo": "Thông tin Cơ bản",
-        "about": "Giới thiệu", 
-        "professional": "Chuyên môn",
-        "contact": "Liên hệ",
-        "portfolio": "Portfolio",
-        "saveChanges": "Lưu Thay đổi",
-        "saveChangesWithCount": "Lưu Thay đổi ({{count}} thay đổi)",
-        "saving": "Đang Lưu...",
-        "backToProfile": "Quay lại Hồ sơ",
-        "discardChanges": "Hủy bỏ Thay đổi?",
-        "discardChangesDescription": "Bạn có muốn hủy bỏ {{count}} thay đổi? Nếu đồng ý, các chỉnh sửa của bạn sẽ không được lưu.",
-        "cancel": "Hủy"
-    },
-    "BasicInfoSection": {
-        "basicInfo": "Thông tin Cơ bản",
-        "firstName": "Tên",
-        "lastName": "Họ",
-        "displayName": "Tên Hiển thị",
-        "location": "Địa điểm"
-    },
-    "AboutSection": {
-        "about": "Giới thiệu",
-        "placeholder": "Hãy kể về bản thân bạn..."
-    },
-    "ContactSection": {
-        "contact": "Liên hệ",
-        "email": "Email", 
-        "phone": "Số điện thoại",
-        "socialLinks": "Mạng xã hội",
-        "instagram": "Instagram",
-        "facebook": "Facebook"
-    },
-    "ProfessionalSection": {
-        "professional": "Chuyên môn",
-        "currentIndustries": "Ngành nghề Hiện tại",
-        "experience": "Kinh nghiệm",
-        "select": "Chọn Ngành nghề",
-        "search": "Tìm kiếm Ngành nghề",
-        "noExperienceFound": "Không tìm thấy Ngành nghề"
-    },
-    "contacts": "Danh bạ",
-    "activity": "Hoạt động",
-    "settings": "Cài đặt",
-    "openToCollab": "Sẵn sàng Hợp tác",
-    "edit": "Chỉnh sửa",
-    "portfolio": "Portfolio",
+  "navigation": {
+    "editProfile": "Chỉnh sửa Hồ sơ",
+    "editPortfolio": "Chỉnh sửa Portfolio",
+    "basicInfo": "Thông tin Cơ bản",
     "about": "Giới thiệu",
-    "industry": "Ngành nghề",
-    "experience": "Kinh nghiệm", 
-    "skills": "Kỹ năng",
+    "professional": "Chuyên môn",
     "contact": "Liên hệ",
+    "portfolio": "Portfolio",
+    "saveChanges": "Lưu Thay đổi",
+    "saveChangesWithCount": "Lưu Thay đổi ({{count}} thay đổi)",
+    "saving": "Đang Lưu...",
+    "backToProfile": "Quay lại Hồ sơ",
+    "discardChanges": "Hủy bỏ Thay đổi?",
+    "discardChangesDescription": "Bạn có muốn hủy bỏ {{count}} thay đổi? Nếu đồng ý, các chỉnh sửa của bạn sẽ không được lưu.",
+    "cancel": "Hủy"
+  },
+  "BasicInfoSection": {
+    "basicInfo": "Thông tin Cơ bản",
+    "firstName": "Tên",
+    "lastName": "Họ",
+    "userName": "Tên Người dùng",
+    "displayName": "Tên Hiển thị",
+    "location": "Địa điểm"
+  },
+  "AboutSection": {
+    "about": "Giới thiệu",
+    "placeholder": "Hãy kể về bản thân bạn..."
+  },
+  "ContactSection": {
+    "contact": "Liên hệ",
+    "email": "Email",
+    "phone": "Số điện thoại",
     "socialLinks": "Mạng xã hội",
-    "seeMore": "Xem thêm"
+    "instagram": "Instagram",
+    "facebook": "Facebook"
+  },
+  "ProfessionalSection": {
+    "professional": "Chuyên môn",
+    "currentIndustries": "Ngành nghề Hiện tại",
+    "experience": "Kinh nghiệm",
+    "select": "Chọn Ngành nghề",
+    "search": "Tìm kiếm Ngành nghề",
+    "noExperienceFound": "Không tìm thấy Ngành nghề"
+  },
+  "contacts": "Danh bạ",
+  "activity": "Hoạt động",
+  "settings": "Cài đặt",
+  "openToCollab": "Sẵn sàng Hợp tác",
+  "edit": "Chỉnh sửa",
+  "portfolio": "Portfolio",
+  "about": "Giới thiệu",
+  "industry": "Ngành nghề",
+  "experience": "Kinh nghiệm",
+  "skills": "Kỹ năng",
+  "contact": "Liên hệ",
+  "socialLinks": "Mạng xã hội",
+  "seeMore": "Xem thêm"
 }

--- a/services/user-service.ts
+++ b/services/user-service.ts
@@ -1,39 +1,82 @@
-import { z } from 'zod'
+import { z } from "zod";
 
-import { writeUserInfo } from '@/app/actions/user/writeUserInfo'
-import { type AboutInfoData } from '@/app/form-schemas/about-info'
-import { contactInfoSchema, type ContactInfoData } from '@/app/form-schemas/contact-info'
-import { professionalInfoSchema, type ProfessionalInfoData } from '@/app/form-schemas/professional-info'
+import { writeUserInfo } from "@/app/actions/user/writeUserInfo";
+import { type AboutInfoData } from "@/app/form-schemas/about-info";
+import {
+  contactInfoSchema,
+  type ContactInfoData,
+} from "@/app/form-schemas/contact-info";
+import {
+  professionalInfoSchema,
+  type ProfessionalInfoData,
+} from "@/app/form-schemas/professional-info";
 
 export class UserService {
   static async updateUserInfo(
     userId: string,
-    data: Partial<ContactInfoData & ProfessionalInfoData & AboutInfoData>
+    data: Partial<ContactInfoData & ProfessionalInfoData & AboutInfoData>,
   ) {
     const {
-      firstName, lastName, location,
-      email, phoneCountryCode, phoneNumber, phoneCountryAlpha3, instagramHandle, facebookHandle,
-      industries, experience,
-      about
-    } = data
+      firstName,
+      lastName,
+      userName,
+      displayName,
+      location,
+      email,
+      phoneCountryCode,
+      phoneNumber,
+      phoneCountryAlpha3,
+      instagramHandle,
+      facebookHandle,
+      industries,
+      experience,
+      about,
+    } = data;
 
     return await writeUserInfo(
       userId,
       {
-        firstName: firstName || '',
-        lastName: lastName || '',
-        phoneCountryCode: phoneCountryCode || '84',
-        phoneNumber: phoneNumber || '',
-        phoneCountryAlpha3: phoneCountryAlpha3 || 'VNM',
+        firstName: firstName || "",
+        lastName: lastName || "",
+        userName: userName || "",
+        displayName: displayName || "",
+        phoneCountryCode: phoneCountryCode || "84",
+        phoneNumber: phoneNumber || "",
+        phoneCountryAlpha3: phoneCountryAlpha3 || "VNM",
       },
       {
-        industries: industries || [] as ("Advertising" | "Architecture" | "Arts and Crafts" | "Design" | "Fashion" | "Film, Video, and Photography" | "Music" | "Performing Arts" | "Publishing" | "Software and Interactive" | "Television and Radio" | "Visual Arts" | "Other")[],
-        experience: experience || null as "Entry" | "Junior" | "Mid-level" | "Senior" | "Manager" | "C-level" | null,
+        industries:
+          industries ||
+          ([] as (
+            | "Advertising"
+            | "Architecture"
+            | "Arts and Crafts"
+            | "Design"
+            | "Fashion"
+            | "Film, Video, and Photography"
+            | "Music"
+            | "Performing Arts"
+            | "Publishing"
+            | "Software and Interactive"
+            | "Television and Radio"
+            | "Visual Arts"
+            | "Other"
+          )[]),
+        experience:
+          experience ||
+          (null as
+            | "Entry"
+            | "Junior"
+            | "Mid-level"
+            | "Senior"
+            | "Manager"
+            | "C-level"
+            | null),
       },
       {
         instagramHandle,
         facebookHandle,
-      }
-    )
+      },
+    );
   }
 }

--- a/supabase/migrations/20241113121229_add_user_name_to_user_infos.sql
+++ b/supabase/migrations/20241113121229_add_user_name_to_user_infos.sql
@@ -1,0 +1,44 @@
+-- Migration: add_user_name_to_user_infos
+-- Created at: 2024-11-13 19:13:29
+-- Description: Adds user_name column to the user_infos table
+--
+BEGIN;
+
+-- Step 1: Add user_name column without NOT NULL constraint
+ALTER TABLE user_infos
+ADD COLUMN user_name TEXT;
+
+-- Step 2: Update existing rows with unique default values
+UPDATE user_infos
+SET user_name = CONCAT('default_user_name_', id)
+WHERE user_name IS NULL;
+
+-- Step 3: Add UNIQUE constraint
+ALTER TABLE user_infos
+ADD CONSTRAINT user_name_unique UNIQUE (user_name);
+
+-- Step 4: Alter column to add NOT NULL constraint
+ALTER TABLE user_infos
+ALTER COLUMN user_name SET NOT NULL;
+
+-- Verification
+DO $$
+BEGIN
+    -- Check if the user_name column has been added
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'user_infos'
+          AND column_name = 'user_name'
+    ) THEN
+        RAISE EXCEPTION 'Column "user_name" was not added to user_infos table';
+    END IF;
+END $$;
+-- Rollback function
+-- CREATE OR REPLACE FUNCTION rollback_add_user_name_to_user_infos()
+-- RETURNS void AS $$
+-- BEGIN
+--     ALTER TABLE user_infos DROP COLUMN IF EXISTS user_name;
+-- END;
+-- $$ LANGUAGE plpgsql;
+COMMIT;


### PR DESCRIPTION
## Description

This PR implements a unique username and a display name for each user

## Key Changes

1. Add a new migration `add_user_name_to_user_infos`
2. Display username and display name
3. Edit username and display name from `/profile/edit`

## Breaking Changes

- [List any breaking changes, if applicable]

## Related Issues

- Addresses WEB-220
- Addresses WEB-221

## Testing Instructions

None

## Additional Notes

None