### PR TITLE
feat(portfolio): change the layout in Portfolio Edit page and make media vertically scrollable

### DIFF
--- a/app/(protected)/portfolio/[artworkId]/PortfolioEditForm.tsx
+++ b/app/(protected)/portfolio/[artworkId]/PortfolioEditForm.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { MediaUpload } from "@/components/uploads/media-upload";
+import UploadProgressBar from "@/components/uploads/DataUsage";
 import { ThumbnailProvider } from "@/contexts/ThumbnailContext";
 import { PortfolioArtworkWithDetails } from "@/drizzle/schema/portfolio";
 import { useTranslation } from "@/lib/i18n/init-client";
@@ -16,6 +17,7 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
+import DataUsage from "@/components/uploads/DataUsage";
 
 interface ArtworkFormValues {
   title: string;
@@ -59,24 +61,26 @@ export default function PortfolioEditForm({
 
   // Fetch artwork assets if editing existing artwork
   const { data: artworkWithAssets, isLoading } = useQuery<ArtworkWithAssets[]>({
-    queryKey: ['artwork', artwork?.artworks?.id],
+    queryKey: ["artwork", artwork?.artworks?.id],
     queryFn: async () => {
       if (!artwork?.artworks?.id) {
         return [];
       }
-      const response = await fetch(`/api/artworks/${artwork.artworks.id}/assets`);
-      if (!response.ok) throw new Error('Failed to fetch artwork assets');
+      const response = await fetch(
+        `/api/artworks/${artwork.artworks.id}/assets`,
+      );
+      if (!response.ok) throw new Error("Failed to fetch artwork assets");
       return response.json();
     },
-    enabled: !!artwork?.artworks?.id
+    enabled: !!artwork?.artworks?.id,
   });
 
   const handleSubmit = async (formData: ArtworkFormValues) => {
     try {
       // Create or update artwork
-      const artworkResponse = await fetch('/api/artworks', {
-        method: isNew ? 'POST' : 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+      const artworkResponse = await fetch("/api/artworks", {
+        method: isNew ? "POST" : "PUT",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           ...formData,
           id: artwork?.artworks?.id,
@@ -84,7 +88,7 @@ export default function PortfolioEditForm({
       });
 
       if (!artworkResponse.ok) {
-        throw new Error('Failed to save artwork');
+        throw new Error("Failed to save artwork");
       }
 
       const savedArtwork = await artworkResponse.json();
@@ -92,26 +96,26 @@ export default function PortfolioEditForm({
       // Handle file uploads if any
       if (pendingFiles.length > 0) {
         const formData = new FormData();
-        pendingFiles.forEach(file => {
-          formData.append('files', file);
+        pendingFiles.forEach((file) => {
+          formData.append("files", file);
         });
-        formData.append('artworkId', savedArtwork.id);
+        formData.append("artworkId", savedArtwork.id);
 
-        const uploadResponse = await fetch('/api/uploads', {
-          method: 'POST',
+        const uploadResponse = await fetch("/api/uploads", {
+          method: "POST",
           body: formData,
         });
 
         if (!uploadResponse.ok) {
-          throw new Error('Failed to upload files');
+          throw new Error("Failed to upload files");
         }
       }
 
       // Update portfolio artwork
       // TODO: This endpoint is not implemented yet
-      const portfolioResponse = await fetch('/api/portfolio-artworks', {
-        method: isNew ? 'POST' : 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+      const portfolioResponse = await fetch("/api/portfolio-artworks", {
+        method: isNew ? "POST" : "PUT",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           id: artwork?.portfolioArtworks?.id,
           userId: userData.id,
@@ -120,47 +124,86 @@ export default function PortfolioEditForm({
       });
 
       if (!portfolioResponse.ok) {
-        throw new Error('Failed to update portfolio');
+        throw new Error("Failed to update portfolio");
       }
 
       // Redirect back to portfolio page
-      router.push('/profile');
+      router.push("/profile");
       router.refresh();
     } catch (error) {
-      console.error('Error saving portfolio artwork:', error);
+      console.error("Error saving portfolio artwork:", error);
       // Handle error (show toast notification, etc.)
     }
   };
 
   return (
-    <Card className="w-full">
-      <CardHeader>
-        <CardTitle>
-          {isNew ? t("newProject") : t("editProject")}
-        </CardTitle>
-      </CardHeader>
+    <FormProvider {...form}>
+      <div className="flex flex-row space-x-8">
+        <Card className="w-full" style={{ flex: 7 }}>
+          <CardHeader>
+            <CardTitle>{isNew ? t("newProject") : t("editProject")}</CardTitle>
+          </CardHeader>
 
-      <CardContent>
-        <FormProvider {...form}>
-          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-8">
-            <Tabs value={activeTab} onValueChange={setActiveTab}>
-              <TabsList className="grid w-full grid-cols-3">
-                <TabsTrigger value="info">{t("projectInfo")}</TabsTrigger>
-                <TabsTrigger value="media">{t("projectMedia")}</TabsTrigger>
-                <TabsTrigger value="credits">{t("projectCredits")}</TabsTrigger>
-              </TabsList>
-
-              <TabsContent value="info" className="space-y-4">
-                <ArtworkInfoStep 
-                  form={form as any} 
-                  artworks={artwork?.artworks ? [{
-                    ...artwork.artworks,
-                    description: artwork.artworks.description || "",
-                  }] : []} 
+          <CardContent>
+            <form
+              onSubmit={form.handleSubmit(handleSubmit)}
+              className="flex flex-col space-y-8"
+            >
+              <div className="flex flex-col space-y-4">
+                <ArtworkInfoStep
+                  form={form as any}
+                  artworks={
+                    artwork?.artworks
+                      ? [
+                          {
+                            ...artwork.artworks,
+                            description: artwork.artworks.description || "",
+                          },
+                        ]
+                      : []
+                  }
                 />
-              </TabsContent>
 
-              <TabsContent value="media" className="space-y-4">
+                {pendingFiles.length > 0 && (
+                  <p className="text-sm text-muted-foreground">
+                    {pendingFiles.reduce((acc, file) => acc + file.size, 0) /
+                      1024 /
+                      1024}{" "}
+                    MB
+                  </p>
+                )}
+
+                {!isNew && !isLoading && artworkWithAssets && (
+                  <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
+                    {artworkWithAssets.map(
+                      (item, index) =>
+                        item.assets && (
+                          <div
+                            key={item.assets.id}
+                            className="relative aspect-square"
+                          >
+                            {item.assets.assetType === "video" ? (
+                              <video
+                                src={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/artwork_assets/${item.assets.filePath}#t=0.05`}
+                                controls
+                                className="h-full w-full object-cover"
+                              >
+                                Your browser does not support the video tag.
+                              </video>
+                            ) : (
+                              <Image
+                                src={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/artwork_assets/${item.assets.filePath}`}
+                                alt={`${artwork?.artworks?.title || "Untitled"} - Asset ${index + 1}`}
+                                fill
+                                className="object-cover"
+                              />
+                            )}
+                          </div>
+                        ),
+                    )}
+                  </div>
+                )}
+
                 <ThumbnailProvider>
                   <MediaUpload
                     isNewArtwork={isNew}
@@ -168,58 +211,52 @@ export default function PortfolioEditForm({
                     onPendingFilesUpdate={setPendingFiles}
                   />
                 </ThumbnailProvider>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
 
-                {!isNew && !isLoading && artworkWithAssets && (
-                  <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                    {artworkWithAssets.map((item, index) => (
-                      item.assets && (
-                        <div
-                          key={item.assets.id}
-                          className="relative aspect-square"
-                        >
-                          {item.assets.assetType === "video" ? (
-                            <video
-                              src={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/artwork_assets/${item.assets.filePath}#t=0.05`}
-                              controls
-                              className="h-full w-full object-cover"
-                            >
-                              Your browser does not support the video tag.
-                            </video>
-                          ) : (
-                            <Image
-                              src={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/artwork_assets/${item.assets.filePath}`}
-                              alt={`${artwork?.artworks?.title || 'Untitled'} - Asset ${index + 1}`}
-                              fill
-                              className="object-cover"
-                            />
-                          )}
-                        </div>
-                      )
-                    ))}
-                  </div>
-                )}
-              </TabsContent>
+        <div className="flex w-full flex-col" style={{ flex: 3 }}>
+          <Card className="mb-4 w-full">
+            <CardHeader>
+              <CardTitle>{t("creditInfo")}</CardTitle>
+            </CardHeader>
 
-              <TabsContent value="credits" className="space-y-4">
+            <CardContent>
+              <div className="flex flex-col space-y-4">
                 <ArtworkCreditInfoStep form={form as any} />
-              </TabsContent>
-            </Tabs>
+              </div>
+            </CardContent>
+          </Card>
 
-            <div className="flex justify-end gap-4">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => router.push('/profile')}
-              >
-                {t("cancel")}
-              </Button>
-              <Button type="submit">
-                {isNew ? t("create") : t("save")}
-              </Button>
-            </div>
-          </form>
-        </FormProvider>
-      </CardContent>
-    </Card>
+          <Card className="mt-auto w-full">
+            <CardHeader>
+              <CardTitle>{t("dataUsage")}</CardTitle>
+            </CardHeader>
+
+            <CardContent>
+              <div className="mt-1">
+                <DataUsage />
+              </div>
+            </CardContent>
+          </Card>
+          <div className="mt-4 flex flex-col gap-4">
+            <Button type="submit" className="w-full">
+              {isNew ? t("create") : t("save")}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              onClick={() => router.push("/profile")}
+            >
+              {t("cancel")}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-8 flex justify-end gap-4"></div>
+    </FormProvider>
   );
 }

--- a/app/(protected)/portfolio/[artworkId]/PortfolioEditForm.tsx
+++ b/app/(protected)/portfolio/[artworkId]/PortfolioEditForm.tsx
@@ -172,31 +172,38 @@ export default function PortfolioEditForm({
                     MB
                   </p>
                 )}
-
                 {!isNew && !isLoading && artworkWithAssets && (
-                  <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
+                  <div
+                    className="overflow-auto"
+                    style={{ maxHeight: "calc(100vh - 200px)" }}
+                  >
                     {artworkWithAssets.map(
                       (item, index) =>
                         item.assets && (
                           <div
                             key={item.assets.id}
-                            className="relative aspect-square"
+                            className="relative mb-4 w-full"
+                            style={index < 2 ? { zIndex: 10 } : {}}
                           >
                             {item.assets.assetType === "video" ? (
                               <video
                                 src={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/artwork_assets/${item.assets.filePath}#t=0.05`}
                                 controls
-                                className="h-full w-full object-cover"
+                                className="w-full"
                               >
                                 Your browser does not support the video tag.
                               </video>
                             ) : (
-                              <Image
-                                src={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/artwork_assets/${item.assets.filePath}`}
-                                alt={`${artwork?.artworks?.title || "Untitled"} - Asset ${index + 1}`}
-                                fill
-                                className="object-cover"
-                              />
+                              <div className="relative h-auto w-full">
+                                <Image
+                                  src={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/artwork_assets/${item.assets.filePath}`}
+                                  alt={`${artwork?.artworks?.title || "Untitled"} - Asset ${index + 1}`}
+                                  layout="responsive"
+                                  width={100}
+                                  height={100}
+                                  className="object-contain"
+                                />
+                              </div>
                             )}
                           </div>
                         ),
@@ -217,7 +224,7 @@ export default function PortfolioEditForm({
         </Card>
 
         <div className="flex w-full flex-col" style={{ flex: 3 }}>
-          <Card className="mb-4 w-full">
+          <Card className="w-full">
             <CardHeader>
               <CardTitle>{t("creditInfo")}</CardTitle>
             </CardHeader>
@@ -228,30 +235,33 @@ export default function PortfolioEditForm({
               </div>
             </CardContent>
           </Card>
+          <div className="flex-grow"></div>{" "}
+          {/* This div will take up the remaining space */}
+          <div className="sticky bottom-0">
+            <Card className="w-full">
+              <CardHeader>
+                <CardTitle>{t("dataUsage")}</CardTitle>
+              </CardHeader>
 
-          <Card className="mt-auto w-full">
-            <CardHeader>
-              <CardTitle>{t("dataUsage")}</CardTitle>
-            </CardHeader>
-
-            <CardContent>
-              <div className="mt-1">
-                <DataUsage />
-              </div>
-            </CardContent>
-          </Card>
-          <div className="mt-4 flex flex-col gap-4">
-            <Button type="submit" className="w-full">
-              {isNew ? t("create") : t("save")}
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              className="w-full"
-              onClick={() => router.push("/profile")}
-            >
-              {t("cancel")}
-            </Button>
+              <CardContent>
+                <div className="mt-1">
+                  <DataUsage />
+                </div>
+              </CardContent>
+            </Card>
+            <div className="mt-4 flex flex-col gap-4">
+              <Button type="submit" className="w-full">
+                {isNew ? t("create") : t("save")}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full"
+                onClick={() => router.push("/profile")}
+              >
+                {t("cancel")}
+              </Button>
+            </div>
           </div>
         </div>
       </div>

--- a/app/(protected)/portfolio/new/PortfolioCreateForm.tsx
+++ b/app/(protected)/portfolio/new/PortfolioCreateForm.tsx
@@ -10,7 +10,7 @@ import { ArtworkProvider } from "@/contexts/ArtworkContext";
 import { ThumbnailProvider } from "@/contexts/ThumbnailContext";
 import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
-import { v4 as uuidv4 } from 'uuid';
+import { v4 as uuidv4 } from "uuid";
 
 interface PortfolioProjectCardProps {
   project: {
@@ -48,15 +48,15 @@ export function PortfolioProjectCard({ project }: PortfolioProjectCardProps) {
   const handleSubmit = async () => {
     const artworkData = artworkForm.getValues();
     const artworkCreditData = artworkCreditForm.getValues();
-    
+
     // Combine data for submission
     const completeData = {
       artwork: artworkData,
       credits: artworkCreditData,
     };
-    
+
     // Handle submission logic
-    console.log('Complete data:', completeData);
+    console.log("Complete data:", completeData);
   };
 
   return (
@@ -65,10 +65,7 @@ export function PortfolioProjectCard({ project }: PortfolioProjectCardProps) {
         <CardHeader>
           <h3 className="mb-4 text-lg font-medium">Project Info</h3>
           <FormProvider {...artworkForm}>
-            <ArtworkInfoStep 
-              form={artworkForm} 
-              artworks={[]}
-            />
+            <ArtworkInfoStep form={artworkForm} artworks={[]} />
           </FormProvider>
         </CardHeader>
 

--- a/app/(protected)/profile/PortfolioTabs.tsx
+++ b/app/(protected)/profile/PortfolioTabs.tsx
@@ -71,7 +71,9 @@ function ExistingPortfolioProjectCard({
 }: ExistingPortfolioProjectCardProps) {
   const router = useRouter();
   const { t } = useTranslation(lang, "ProfilePage");
-  const { data: artworkWithAssets, isLoading: isLoadingAssets } = useQuery<ArtworkWithAssets[]>({
+  const { data: artworkWithAssets, isLoading: isLoadingAssets } = useQuery<
+    ArtworkWithAssets[]
+  >({
     queryKey: ["artwork-assets", project?.artworks?.id],
     queryFn: async () => {
       if (!project?.artworks?.id) {
@@ -86,7 +88,9 @@ function ExistingPortfolioProjectCard({
     enabled: !!project?.artworks?.id,
   });
 
-  const { data: artworkCredits, isLoading: isLoadingCredits } = useQuery<ArtworkWithCredits[]>({
+  const { data: artworkCredits, isLoading: isLoadingCredits } = useQuery<
+    ArtworkWithCredits[]
+  >({
     queryKey: ["artwork-credits", project?.artworks?.id],
     queryFn: async () => {
       if (!project?.artworks?.id) {
@@ -100,7 +104,6 @@ function ExistingPortfolioProjectCard({
     },
     enabled: !!project?.artworks?.id,
   });
-
 
   if (!project?.artworks) {
     return <div>Project not found</div>;
@@ -133,8 +136,8 @@ function ExistingPortfolioProjectCard({
 
     return (
       <div className="space-y-6">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-          <div className="md:col-span-3 flex flex-col">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+          <div className="flex flex-col md:col-span-3">
             <h4 className="mb-2 font-medium">Description</h4>
             <p className="text-gray-600">
               {project.artworks?.description || "No description provided"}
@@ -146,30 +149,36 @@ function ExistingPortfolioProjectCard({
               <Skeleton className="h-4" />
             ) : (
               <p className="text-gray-600">
-                {artworkCredits && artworkCredits?.length > 0 
-                  ? artworkCredits.map((credit: ArtworkWithCredits) => (
-                      `${credit.displayName || 'Anonymous'} (${credit.title})`
-                    )).join(", ")
-                  : "No artists provided"
-                }
+                {artworkCredits && artworkCredits?.length > 0
+                  ? artworkCredits
+                      .map(
+                        (credit: ArtworkWithCredits) =>
+                          `${credit.displayName || "Anonymous"} (${credit.title})`,
+                      )
+                      .join(", ")
+                  : "No artists provided"}
               </p>
             )}
           </div>
         </div>
         <h4 className="mb-2 font-medium">Media</h4>
-        <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
+        <div
+          className="h-full overflow-auto"
+          style={{ maxHeight: "calc(100vh - 200px)" }}
+        >
           {artworkWithAssets?.map(
             (item, index) =>
               item.assets && (
                 <div
                   key={item.assets.id}
-                  className="relative flex w-full items-center justify-center"
+                  className="relative mb-4 w-full"
+                  style={index < 2 ? { zIndex: 10 } : {}}
                 >
                   {item.assets.assetType === "video" ? (
                     <video
                       src={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/artwork_assets/${item.assets.filePath}#t=0.05`}
                       controls
-                      className="h-auto max-w-full"
+                      className="w-full"
                     >
                       Your browser does not support the video tag.
                     </video>
@@ -177,10 +186,10 @@ function ExistingPortfolioProjectCard({
                     <Image
                       src={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/artwork_assets/${item.assets.filePath}`}
                       alt={`${project.artworks?.title} - Asset ${index + 1}`}
-                      sizes="(min-width: 1024px) 66vw, 100vw"
-                      width={1024}
-                      height={1024}
-                      style={{ objectFit: "contain" }}
+                      layout="responsive"
+                      width={100}
+                      height={100}
+                      className="object-contain"
                     />
                   )}
                 </div>
@@ -194,13 +203,11 @@ function ExistingPortfolioProjectCard({
   return (
     <Card className="w-full">
       <FormProvider {...form}>
-        <CardHeader className="flex flex-col items-left">
+        <CardHeader className="items-left flex flex-col">
           <div className="flex items-center gap-4">
             <Button variant="ghost" size="sm" asChild>
               {project.artworks?.id ? (
-                <Link href={`/portfolio/${project.artworks.id}`}>
-                  Edit
-                </Link>
+                <Link href={`/portfolio/${project.artworks.id}`}>Edit</Link>
               ) : (
                 <span className="text-muted-foreground">Edit</span>
               )}
@@ -213,7 +220,6 @@ function ExistingPortfolioProjectCard({
             <h3 className="text-lg font-medium">
               {project.artworks?.title || "Untitled"}
             </h3>
-
           </div>
         </CardHeader>
 

--- a/components/uploads/DataUsage.tsx
+++ b/components/uploads/DataUsage.tsx
@@ -20,9 +20,6 @@ const DataUsage: React.FC = () => {
   return (
     <div className="flex flex-col">
       <div className="items-left mt-4 flex flex-col">
-        <p className="my-2 flex-grow text-sm font-bold text-muted-foreground">
-          DATA USAGE:
-        </p>
         <p className="flex-grow text-sm text-muted-foreground">
           {formatSize(pendingSize)} of 25MB used
         </p>

--- a/components/uploads/DataUsage.tsx
+++ b/components/uploads/DataUsage.tsx
@@ -1,0 +1,49 @@
+// StorageLimitDisplay.tsx
+import React from "react";
+import usePendingSizeStore from "@/stores/usePendingSizeStore";
+
+const formatSize = (bytes: number) => {
+  if (bytes === 0) return "0 Bytes";
+  const k = 1024;
+  const sizes = ["Bytes", "KB", "MB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
+};
+
+const DataUsage: React.FC = () => {
+  const { pendingSize } = usePendingSizeStore();
+  const maxSize = 25 * 1024 * 1024; // 25MB in bytes
+  const isOverLimit = pendingSize > maxSize;
+  const pendingPercentage = (pendingSize / maxSize) * 100;
+  const remainingPercentage = 100 - pendingPercentage;
+
+  return (
+    <div className="flex flex-col">
+      <div className="items-left mt-4 flex flex-col">
+        <p className="my-2 flex-grow text-sm font-bold text-muted-foreground">
+          DATA USAGE:
+        </p>
+        <p className="flex-grow text-sm text-muted-foreground">
+          {formatSize(pendingSize)} of 25MB used
+        </p>
+      </div>
+      {isOverLimit && (
+        <div className="mt-2 flex items-center text-destructive">
+          <span className="text-xs">Storage limit exceeded!</span>
+        </div>
+      )}
+      <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-gray-200">
+        <div
+          className="float-left h-full bg-primary"
+          style={{ width: `${pendingPercentage}%` }}
+        />
+        <div
+          className="float-left h-full bg-muted"
+          style={{ width: `${remainingPercentage}%` }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default DataUsage;

--- a/components/uploads/media-upload.tsx
+++ b/components/uploads/media-upload.tsx
@@ -1,17 +1,18 @@
-"use client"
+"use client";
 
 // NextJS
-import Link from 'next/link'
+import Link from "next/link";
 // ShadCN
-import { AlertCircle, Upload } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { useDropzone } from 'react-dropzone'
-import { Trans, useTranslation } from 'react-i18next'
+import { AlertCircle, Upload } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useDropzone } from "react-dropzone";
+import { Trans, useTranslation } from "react-i18next";
 // Custom
-import { FileTable } from './FileTable'
+import { FileTable } from "./FileTable";
 // Types
-import { SupabaseFile } from '@/app/types/SupabaseFile'
-import { useThumbnail } from '@/contexts/ThumbnailContext'
+import { SupabaseFile } from "@/app/types/SupabaseFile";
+import { useThumbnail } from "@/contexts/ThumbnailContext";
+import usePendingSizeStore from "@/stores/usePendingSizeStore";
 
 interface MediaUploadProps {
   artworkUUID?: string;
@@ -20,38 +21,49 @@ interface MediaUploadProps {
   onPendingFilesUpdate: (files: File[]) => void;
 }
 
-export function MediaUpload({ 
-  artworkUUID, 
-  isNewArtwork, 
-  emailLink, 
+export function MediaUpload({
+  artworkUUID,
+  isNewArtwork,
+  emailLink,
   onPendingFilesUpdate,
 }: MediaUploadProps) {
-  console.log("MediaUpload component rendering", { artworkUUID, isNewArtwork, emailLink });
+  console.log("MediaUpload component rendering", {
+    artworkUUID,
+    isNewArtwork,
+    emailLink,
+  });
   // Constants
-  const maxSize = 25 * 1024 * 1024 // 25MB in bytes
-  
+  const maxSize = 25 * 1024 * 1024; // 25MB in bytes
+
   // States
-  const [pendingFiles, setPendingFiles] = useState<File[]>([])
+  const [pendingFiles, setPendingFiles] = useState<File[]>([]);
   const { thumbnailFileName, setThumbnailFileName } = useThumbnail();
+  const { pendingSize, setPendingSize } = usePendingSizeStore();
+
   // I18n
-  const { t } = useTranslation(['media-upload'])
+  const { t } = useTranslation(["media-upload"]);
   // Callbacks
-  const onDrop = useCallback((acceptedFiles: File[]) => {
-    setPendingFiles(prevFiles => {
-      const newFiles = [...prevFiles, ...acceptedFiles];
-      if (newFiles.length > 0 && !thumbnailFileName) {
-        const newThumbnailFile = newFiles[0].name;
-        setThumbnailFileName(newThumbnailFile);
-      }
-      // Pass the updated file list to the parent component
-      onPendingFilesUpdate(newFiles);
-      return newFiles;
-    })
-  }, [thumbnailFileName, onPendingFilesUpdate])
+  const onDrop = useCallback(
+    (acceptedFiles: File[]) => {
+      setPendingFiles((prevFiles) => {
+        const newFiles = [...prevFiles, ...acceptedFiles];
+        if (newFiles.length > 0 && !thumbnailFileName) {
+          const newThumbnailFile = newFiles[0].name;
+          setThumbnailFileName(newThumbnailFile);
+        }
+        // Pass the updated file list to the parent component
+        onPendingFilesUpdate(newFiles);
+        return newFiles;
+      });
+    },
+    [thumbnailFileName, onPendingFilesUpdate],
+  );
   // Remove a file from the pending files list
   const removeFile = (fileToRemove: File | SupabaseFile) => {
-    setPendingFiles(prevFiles => {
-      const newFiles = prevFiles.filter(file => file.name !== fileToRemove.name);
+    setPendingFiles((prevFiles) => {
+      const newFiles = prevFiles.filter(
+        (file) => file.name !== fileToRemove.name,
+      );
       if (thumbnailFileName === fileToRemove.name) {
         const newThumbnailFile = newFiles.length > 0 ? newFiles[0].name : null;
         setThumbnailFileName(newThumbnailFile);
@@ -59,33 +71,46 @@ export function MediaUpload({
       // Pass the updated file list to the parent component
       onPendingFilesUpdate(newFiles);
       return newFiles;
-    })
-  }
+    });
+  };
   // Dropzone
-  const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop })
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop });
 
   const formatSize = (bytes: number) => {
-    if (bytes === 0) return '0 Bytes'
-    const k = 1024
-    const sizes = ['Bytes', 'KB', 'MB']
-    const i = Math.floor(Math.log(bytes) / Math.log(k))
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
-  }
+    if (bytes === 0) return "0 Bytes";
+    const k = 1024;
+    const sizes = ["Bytes", "KB", "MB"];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
+  };
 
-  const pendingSize = useMemo(() => pendingFiles.reduce((acc, file) => acc + file.size, 0), [pendingFiles]);
+  useEffect(() => {
+    const size = pendingFiles.reduce((acc, file) => acc + file.size, 0);
+    setPendingSize(size);
+  }, [pendingFiles, setPendingSize]);
+
+  // const pendingSize = useMemo(
+  //   () => pendingFiles.reduce((acc, file) => acc + file.size, 0),
+  //   [pendingFiles],
+  // );
   const totalSize = pendingSize;
 
-  const isOverLimit = totalSize > maxSize
+  const isOverLimit = totalSize > maxSize;
   const pendingPercentage = (pendingSize / maxSize) * 100;
   const remainingPercentage = 100 - pendingPercentage;
 
   return (
-    <div className="w-full max-w-md mx-auto bg-background">
-      <form onSubmit={(e) => { e.preventDefault(); }}>
+    <div className="mx-auto w-full max-w-md bg-background">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+        }}
+      >
         <div
           {...getRootProps()}
-          className={`p-8 border-2 border-dashed rounded-md text-center cursor-pointer transition-colors ${isDragActive ? 'border-primary bg-primary/10' : 'border-border'
-            }`}
+          className={`cursor-pointer rounded-md border-2 border-dashed p-8 text-center transition-colors ${
+            isDragActive ? "border-primary bg-primary/10" : "border-border"
+          }`}
         >
           <input {...getInputProps()} />
           <Upload className="mx-auto h-12 w-12 text-muted-foreground" />
@@ -93,62 +118,64 @@ export function MediaUpload({
             {t("form.dropzone")}
           </p>
         </div>
-        <div className="flex flex-col">
-          <div className="mt-4 flex flex-col items-left">
-            <p className="text-sm font-medium flex-grow text-muted-foreground">
+        {/* <div className="flex flex-col">
+          <div className="items-left mt-4 flex flex-col">
+            <p className="flex-grow text-sm font-medium text-muted-foreground">
               <br />
               <Trans
                 i18nKey="media-upload:form.size.pending"
                 values={{ count: formatSize(pendingSize) }}
                 components={{ strong: <strong /> }}
-              />{' '}
+              />{" "}
               <Trans
                 i18nKey="media-upload:form.size.total"
                 values={{ count: formatSize(pendingSize), limit: "25MB" }}
                 components={{ strong: <strong /> }}
               />
             </p>
-
           </div>
           {isOverLimit && (
-            <div className="flex items-center text-destructive mt-2">
-              <AlertCircle className="h-4 w-4 mr-1" />
-              <span className="text-xs">{t("alert.overLimit", { limit: "25MB" })}</span>
+            <div className="mt-2 flex items-center text-destructive">
+              <AlertCircle className="mr-1 h-4 w-4" />
+              <span className="text-xs">
+                {t("alert.overLimit", { limit: "25MB" })}
+              </span>
             </div>
           )}
-          <div className="mt-2 h-2 w-full bg-gray-200 rounded-full overflow-hidden">
+          <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-gray-200">
             <div
-              className="h-full bg-primary float-left"
+              className="float-left h-full bg-primary"
               style={{ width: `${pendingPercentage}%` }}
             />
             <div
-              className="h-full bg-muted float-left"
+              className="float-left h-full bg-muted"
               style={{ width: `${remainingPercentage}%` }}
             />
           </div>
-        </div>
+        </div> */}
         {pendingFiles.length > 0 && (
           <FileTable
-            files={pendingFiles.map(file => ({
+            files={pendingFiles.map((file) => ({
               id: file.name,
               path: file.name,
               fullPath: file.name,
               name: file.name,
               size: file.size,
-              isThumbnail: file.name === thumbnailFileName
+              isThumbnail: file.name === thumbnailFileName,
             }))}
             isReadonly={false}
             removeFile={removeFile}
           />
         )}
-        <div className="flex space-x-2 items-center">
-          <p className="text-sm text-muted-foreground mt-4">
-            {t("button.email_description")} <Link href={emailLink} className="text-primary hover:underline">
+        <div className="flex items-center space-x-2">
+          <p className="mt-4 text-sm text-muted-foreground">
+            {t("button.email_description")}{" "}
+            <Link href={emailLink} className="text-primary hover:underline">
               {t("button.email")}
             </Link>
           </p>
         </div>
       </form>
     </div>
-  )
+  );
 }

--- a/components/uploads/media-upload.tsx
+++ b/components/uploads/media-upload.tsx
@@ -89,16 +89,6 @@ export function MediaUpload({
     setPendingSize(size);
   }, [pendingFiles, setPendingSize]);
 
-  // const pendingSize = useMemo(
-  //   () => pendingFiles.reduce((acc, file) => acc + file.size, 0),
-  //   [pendingFiles],
-  // );
-  const totalSize = pendingSize;
-
-  const isOverLimit = totalSize > maxSize;
-  const pendingPercentage = (pendingSize / maxSize) * 100;
-  const remainingPercentage = 100 - pendingPercentage;
-
   return (
     <div className="mx-auto w-full max-w-md bg-background">
       <form
@@ -118,41 +108,6 @@ export function MediaUpload({
             {t("form.dropzone")}
           </p>
         </div>
-        {/* <div className="flex flex-col">
-          <div className="items-left mt-4 flex flex-col">
-            <p className="flex-grow text-sm font-medium text-muted-foreground">
-              <br />
-              <Trans
-                i18nKey="media-upload:form.size.pending"
-                values={{ count: formatSize(pendingSize) }}
-                components={{ strong: <strong /> }}
-              />{" "}
-              <Trans
-                i18nKey="media-upload:form.size.total"
-                values={{ count: formatSize(pendingSize), limit: "25MB" }}
-                components={{ strong: <strong /> }}
-              />
-            </p>
-          </div>
-          {isOverLimit && (
-            <div className="mt-2 flex items-center text-destructive">
-              <AlertCircle className="mr-1 h-4 w-4" />
-              <span className="text-xs">
-                {t("alert.overLimit", { limit: "25MB" })}
-              </span>
-            </div>
-          )}
-          <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-gray-200">
-            <div
-              className="float-left h-full bg-primary"
-              style={{ width: `${pendingPercentage}%` }}
-            />
-            <div
-              className="float-left h-full bg-muted"
-              style={{ width: `${remainingPercentage}%` }}
-            />
-          </div>
-        </div> */}
         {pendingFiles.length > 0 && (
           <FileTable
             files={pendingFiles.map((file) => ({

--- a/public/translations/en/Portfolio.json
+++ b/public/translations/en/Portfolio.json
@@ -4,6 +4,8 @@
   "projectInfo": "Project Info",
   "projectMedia": "Media",
   "projectCredits": "Credits",
+  "dataUsage": "Data Usage",
+  "creditInfo": "Credit Info",
   "cancel": "Cancel",
   "create": "Create",
   "save": "Save"

--- a/stores/usePendingSizeStore.ts
+++ b/stores/usePendingSizeStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface PendingSizeState {
+  pendingSize: number;
+  setPendingSize: (size: number) => void;
+}
+
+const usePendingSizeStore = create<PendingSizeState>((set) => ({
+  pendingSize: 0,
+  setPendingSize: (size) => set({ pendingSize: size }),
+}));
+
+export default usePendingSizeStore;


### PR DESCRIPTION
## Description

This PR changes the layout in `/portfolio/{artworkId}` according to Figma and make media vertically scrollable in `Profile Portfolio tab` & `Portfolio Edit page`

## Key Changes

1. Make media vertically scrollable `Profile Portfolio tab` & `Portfolio Edit page`
2. Create a new store `usePendingSizeStore`
3. Separate `DataUsage` to a new component

## Breaking Changes

None

## Related Issues

- Addresses WEB-224
- Addresses WEB-225

## Testing Instructions

None

## Additional Notes

None