### PR TITLE
fix(db): add user_name column to user_infos seed data

### DIFF
--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -166,6 +166,7 @@ INSERT INTO auth.users (
 -- Seed data for user_infos table
 INSERT INTO user_infos (
     id,
+    user_name,
     first_name,
     last_name,
     display_name,
@@ -182,6 +183,7 @@ INSERT INTO user_infos (
     facebook_handle
 ) VALUES (
     '7c37e6b3-5e62-4f76-b67c-0d5a42b92a2d',
+    'admin_user',
     'Admin',
     'User',
     'Admin User',
@@ -198,6 +200,7 @@ INSERT INTO user_infos (
     'admin_fb'
 ), (
     '13f60da9-8dd4-42f9-8a57-c0569a158857',
+    'regular_user',
     'Regular',
     'User',
     'Regular User',
@@ -214,6 +217,7 @@ INSERT INTO user_infos (
     'user_fb'
 ), (
     '314f834c-3ff2-4382-bc92-d37cbe2286a8',
+    'vinhloc30796',
     'Hoang Vinh Loc',
     'Nguyen',
     'Vinh Loc Nguyen',


### PR DESCRIPTION
## Description

Add `user_infos.user_name` to `seed.sql` so that we can fix bug:

```bash
$ supabase db reset
Seeding data from seed.sql...
failed to send batch: ERROR: null value in column "user_name" of relation "user_infos" violates not-null constraint (SQLSTATE 23502)
```

## Key Changes

Add three test values `user_infos.user_name` for local `seed.sql` 

## Breaking Changes

None

## Related Issues

- Closes WEB-229
- Relates to WEB-220

## Testing Instructions

Run `supabase db reset` & check that it has succeeded in inserting data

## Additional Notes

None