### PR TITLE
feat(profile)!: implement unified industry-experience UI

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -16,7 +16,7 @@ import { useRouter } from 'next/navigation'
 import { contactInfoSchema, ContactInfoData } from '@/app/form-schemas/contact-info'
 import { professionalInfoSchema, ProfessionalInfoData } from '@/app/form-schemas/professional-info'
 import { BackgroundDiv } from '@/components/wrappers/BackgroundDiv'
-import { Industry, ExperienceLevel } from '@/app/types/UserInfo'
+import { IndustryType, ExperienceType } from '@/drizzle/schema/user'
 
 const signupSchema = z.object({
   ...contactInfoSchema.shape,
@@ -57,8 +57,7 @@ export default function SignupPage({
     resolver: zodResolver(professionalInfoSchema),
     mode: 'onSubmit',
     defaultValues: {
-      industries: [],
-      experience: undefined,
+      industryExperiences: []
     },
   })
 
@@ -73,8 +72,7 @@ export default function SignupPage({
         phoneCountryAlpha3: userData.phoneCountryAlpha3 ?? 'VNM',
       })
       professionalInfoForm.reset({
-        industries: userData.industries || [],
-        experience: userData.experience || undefined,
+        industryExperiences: userData.industryExperiences || []
       })
     }
   }, [userData, isLoading, contactInfoForm, professionalInfoForm])
@@ -125,8 +123,10 @@ export default function SignupPage({
           lastName: contactInfoData.lastName,
         },
         {
-          industries: professionalInfoData.industries as Industry[],
-          experience: professionalInfoData.experience as ExperienceLevel | null,
+          industryExperiences: professionalInfoData.industryExperiences.map(exp => ({
+            industry: exp.industry as IndustryType,
+            experienceLevel: exp.experienceLevel as ExperienceType
+          }))
         },
         {
           instagramHandle: contactInfoData.instagramHandle,

--- a/app/(public)/(event)/api/event-artworks/helper.ts
+++ b/app/(public)/(event)/api/event-artworks/helper.ts
@@ -1,0 +1,75 @@
+import { db } from "@/lib/db";
+import { eq } from "drizzle-orm";
+import { artworks, artworkAssets, artworkCredits, artworkEvents } from "@/drizzle/schema/artwork";
+import { events } from "@/drizzle/schema/event";
+import { userInfos, UserInfo } from "@/drizzle/schema/user";
+import { ArtworkWithAssetsThumbnailCredits } from "@/components/artwork/ArtworkCard";
+
+export async function fetchEventArtworks(eventId: string): Promise<Record<string, ArtworkWithAssetsThumbnailCredits>> {
+  // Fetch artworks and their assets for the event
+  const eventArtworks = await db
+    .select({
+      artwork: artworks,
+      assets: artworkAssets, 
+      credits: artworkCredits,
+      user: userInfos,
+    })
+    .from(artworkEvents)
+    .innerJoin(artworks, eq(artworkEvents.artworkId, artworks.id))
+    .leftJoin(artworkAssets, eq(artworks.id, artworkAssets.artworkId))
+    .leftJoin(artworkCredits, eq(artworks.id, artworkCredits.artworkId))
+    .leftJoin(userInfos, eq(artworkCredits.userId, userInfos.id))
+    .where(eq(artworkEvents.eventId, eventId));
+
+  // Process fetched artworks to group assets with their respective artworks
+  const processedArtworks = eventArtworks.reduce(
+    (acc, { artwork, assets, credits, user }) => {
+      if (!acc[artwork.id]) {
+        acc[artwork.id] = {
+          ...artwork,
+          assets: [],
+          thumbnail: null,
+          credits: [],
+        };
+      }
+
+      if (assets && !acc[artwork.id].assets.some((a) => a.id === assets.id)) {
+        acc[artwork.id].assets.push(assets);
+        if (assets.isThumbnail) {
+          acc[artwork.id].thumbnail = {
+            filePath: assets.filePath,
+            assetType: assets.assetType || "image",
+          };
+        }
+      }
+
+      if (credits && !acc[artwork.id].credits.some((c) => c.id === credits.id)) {
+        const userInfo: UserInfo = user
+          ? {
+              ...user
+            }
+          : {
+              id: credits.userId,
+              firstName: null,
+              lastName: null,
+              userName: null, 
+              displayName: "Anonymous",
+              phoneCountryCode: null,
+              phoneNumber: null,
+              phoneCountryAlpha3: null,
+              location: null,
+              occupation: null,
+              about: null,
+              profilePicture: null,
+              instagramHandle: null,
+              facebookHandle: null,
+            };
+        acc[artwork.id].credits.push({ ...credits, user: userInfo });
+      }
+      return acc;
+    },
+    {} as Record<string, ArtworkWithAssetsThumbnailCredits>
+  );
+
+  return processedArtworks;
+}

--- a/app/(public)/(event)/api/event-artworks/route.ts
+++ b/app/(public)/(event)/api/event-artworks/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { fetchEventArtworks } from "./helper";
+
+export async function GET(
+  request: Request,
+  { params }: { params: { eventSlug: string } }
+) {
+  try {
+    // Extract eventSlug from URL
+    const url = new URL(request.url);
+    const eventSlug = url.searchParams.get("eventSlug");
+
+    if (!eventSlug) {
+      return NextResponse.json(
+        { error: "Event slug is required" },
+        { status: 400 }
+      );
+    }
+
+    // Fetch event artworks using helper function
+    const eventArtworks = await fetchEventArtworks(eventSlug);
+
+    if (!eventArtworks) {
+      return NextResponse.json(
+        { error: "Event not found" },
+        { status: 404 }
+      );
+    }
+
+    // Return successful response with event artworks data
+    return NextResponse.json(eventArtworks);
+
+  } catch (error) {
+    console.error("Error fetching event artworks:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/(public)/(event)/api/events/[slug]/helper.ts
+++ b/app/(public)/(event)/api/events/[slug]/helper.ts
@@ -1,0 +1,23 @@
+import { db } from "@/lib/db";
+import { eq } from "drizzle-orm";
+import { events } from "@/drizzle/schema/event";
+
+export async function fetchEvent(slug: string) {
+  try {
+    // Fetch event data from the database
+    const eventData = await db.query.events.findFirst({
+      where: eq(events.slug, slug),
+      columns: {
+        id: true,
+        name: true, 
+        slug: true,
+        time_end: true
+      }
+    });
+
+    return eventData;
+  } catch (error) {
+    console.error("Error fetching event:", error);
+    return null;
+  }
+}

--- a/app/(public)/(event)/api/events/[slug]/route.ts
+++ b/app/(public)/(event)/api/events/[slug]/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { fetchEvent } from "./helper";
+
+export async function GET(
+  request: Request,
+  { params }: { params: { slug: string } }
+) {
+  try {
+    const { slug } = params;
+
+    // Fetch event data using helper function
+    const eventData = await fetchEvent(slug);
+
+    if (!eventData) {
+      return NextResponse.json(
+        { error: "Event not found" },
+        { status: 404 }
+      );
+    }
+
+    // Return successful response with event data
+    return NextResponse.json(eventData);
+
+  } catch (error) {
+    console.error("Error in event route:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/(public)/(event)/api/recent-events/helper.ts
+++ b/app/(public)/(event)/api/recent-events/helper.ts
@@ -1,0 +1,25 @@
+import { db } from "@/lib/db";
+import { desc } from "drizzle-orm";
+import { events } from "@/drizzle/schema/event";
+
+export async function fetchRecentEvents(limit: number = 5) {
+  try {
+    // Fetch recent events ordered by creation date
+    const recentEvents = await db.query.events.findMany({
+      orderBy: desc(events.created_at),
+      limit: limit,
+      columns: {
+        id: true,
+        name: true,
+        slug: true,
+        time_end: true,
+        created_at: true
+      }
+    });
+
+    return recentEvents;
+  } catch (error) {
+    console.error("Error fetching recent events:", error);
+    return [];
+  }
+}

--- a/app/(public)/(event)/api/recent-events/route.ts
+++ b/app/(public)/(event)/api/recent-events/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { fetchRecentEvents } from "./helper";
+
+export async function GET(request: Request) {
+  try {
+    // Extract limit from URL query params if provided
+    const url = new URL(request.url);
+    const limit = url.searchParams.get("limit");
+    const limitNum = limit ? parseInt(limit) : 5;
+
+    // Fetch recent events using helper function
+    const recentEvents = await fetchRecentEvents(limitNum);
+
+    // Return successful response with recent events data
+    return NextResponse.json(recentEvents);
+
+  } catch (error) {
+    console.error("Error in recent events route:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/(public)/(event)/register/_sections/ProfessionalInfoForm.tsx
+++ b/app/(public)/(event)/register/_sections/ProfessionalInfoForm.tsx
@@ -1,0 +1,190 @@
+"use client"
+
+import { ProfessionalInfoData } from '@/app/form-schemas/professional-info';
+import { Button } from '@/components/ui/button';
+import { Check, ChevronsUpDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { industriesMapper, experienceLevelsMapper, experienceLevels, industries } from '@/drizzle/schema/user';
+import { useForm, useFieldArray } from 'react-hook-form';
+import { useState } from 'react';
+
+export const ProfessionalInfoForm = () => {
+  const { control } = useForm<ProfessionalInfoData>();
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "industryExperiences"
+  });
+
+  // Lift state up to parent component
+  const [fieldStates, setFieldStates] = useState(
+    fields.map(() => ({
+      industryOpen: false,
+      experienceOpen: false,
+      industry: "",
+      experience: ""
+    }))
+  );
+
+  const updateFieldState = (index: number, updates: Partial<typeof fieldStates[0]>) => {
+    setFieldStates(prev => {
+      const newStates = [...prev];
+      newStates[index] = { ...newStates[index], ...updates };
+      return newStates;
+    });
+  };
+
+  return (
+    <form>
+      {fields.map((field, index) => {
+        const currentState = fieldStates[index] || {
+          industryOpen: false,
+          experienceOpen: false,
+          industry: "",
+          experience: ""
+        };
+
+        return (
+          <div key={field.id} className="flex gap-4 items-center mb-4">
+            <Popover 
+              open={currentState.industryOpen} 
+              onOpenChange={(open) => updateFieldState(index, { industryOpen: open })}
+            >
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  role="combobox"
+                  aria-expanded={currentState.industryOpen}
+                  className="w-[200px] justify-between"
+                >
+                  {currentState.industry
+                    ? industriesMapper.find((i) => i.value === currentState.industry)?.label
+                    : "Select industry..."}
+                  <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-[200px] p-0">
+                <Command>
+                  <CommandInput placeholder="Search industry..." />
+                  <CommandList>
+                    <CommandEmpty>No industry found.</CommandEmpty>
+                    <CommandGroup>
+                      {industriesMapper.map((ind) => (
+                        <CommandItem
+                          key={ind.value}
+                          value={ind.value}
+                          onSelect={(currentValue) => {
+                            updateFieldState(index, {
+                              industry: currentValue === currentState.industry ? "" : currentValue,
+                              industryOpen: false
+                            });
+                          }}
+                        >
+                          <Check
+                            className={cn(
+                              "mr-2 h-4 w-4",
+                              currentState.industry === ind.value ? "opacity-100" : "opacity-0"
+                            )}
+                          />
+                          {ind.label}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
+
+            <Popover 
+              open={currentState.experienceOpen} 
+              onOpenChange={(open) => updateFieldState(index, { experienceOpen: open })}
+            >
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  role="combobox"
+                  aria-expanded={currentState.experienceOpen}
+                  className="w-[200px] justify-between"
+                >
+                  {currentState.experience
+                    ? experienceLevelsMapper.find((e) => e.value === currentState.experience)?.label
+                    : "Select experience..."}
+                  <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-[200px] p-0">
+                <Command>
+                  <CommandInput placeholder="Search experience level..." />
+                  <CommandList>
+                    <CommandEmpty>No experience level found.</CommandEmpty>
+                    <CommandGroup>
+                      {experienceLevelsMapper.map((exp) => (
+                        <CommandItem
+                          key={exp.value}
+                          value={exp.value}
+                          onSelect={(currentValue) => {
+                            updateFieldState(index, {
+                              experience: currentValue === currentState.experience ? "" : currentValue,
+                              experienceOpen: false
+                            });
+                          }}
+                        >
+                          <Check
+                            className={cn(
+                              "mr-2 h-4 w-4",
+                              currentState.experience === exp.value ? "opacity-100" : "opacity-0"
+                            )}
+                          />
+                          {exp.label}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
+
+            <Button 
+              type="button" 
+              variant="destructive"
+              onClick={() => remove(index)}
+            >
+              Remove
+            </Button>
+          </div>
+        );
+      })}
+      
+      <Button
+        type="button"
+        onClick={() => {
+          append({ 
+            industry: industries[0], 
+            experienceLevel: experienceLevels[0] 
+          });
+          setFieldStates(prev => [...prev, {
+            industryOpen: false,
+            experienceOpen: false,
+            industry: "",
+            experience: ""
+          }]);
+        }}
+        className="mt-4"
+      >
+        Add Industry Experience
+      </Button>
+    </form>
+  );
+};

--- a/app/(public)/(event)/register/_sections/RegistrationForm.tsx
+++ b/app/(public)/(event)/register/_sections/RegistrationForm.tsx
@@ -1,158 +1,195 @@
 // File: app/(public)/(event)/register/_sections/RegistrationForm.tsx
 
-'use client'
+"use client";
 
-import { getUserId } from '@/app/actions/user/auth'
-import { ContactInfoData, contactInfoSchema } from '@/app/form-schemas/contact-info'
-import { EventRegistrationData, eventRegistrationSchema } from '@/app/form-schemas/event-registration'
-import { ProfessionalInfoData, professionalInfoSchema } from '@/app/form-schemas/professional-info'
-import { EventRegistrationWithSlot } from '@/app/types/EventRegistration'
-import { EventSlot } from '@/app/types/EventSlot'
-import { Button } from '@/components/ui/button'
-import { Progress } from '@/components/ui/progress'
-import { useAuth } from '@/hooks/useAuth'; // Import the new hook
-import { cn } from '@/lib/utils'
-import { zodResolver } from '@hookform/resolvers/zod'
-import React, { useEffect, useState } from 'react'
-import { FormProvider, useForm, UseFormReturn } from 'react-hook-form'
-import { ContactInfoStep } from '../../../../../components/user/ContactInfoStep'
-import { ProfessionalInfoStep } from '../../../../../components/user/ProfessionalInfoStep'
-import { ConfirmationPage } from './ConfirmationPage'
-import { ConfirmationStep } from './ConfirmationStep'
-import { DateSelectionStep } from './DateSelectionStep'
-import { EmailExistedStep } from './EmailExistedStep'
-import { checkExistingRegistration, createRegistration } from './actions'
-import { writeUserInfo } from "@/app/actions/user/writeUserInfo"
-import { signUpUser } from "@/app/actions/user/signUp"
-import { formSchema, FormData } from './formSchema'
-import { useFormUserId } from '@/hooks/useFormUserId'
-import { ExperienceLevel, Industry } from '@/app/types/UserInfo'
-import { IndustryType } from '@/drizzle/schema/user'
-import { ExperienceType } from '@/drizzle/schema/user'
+import { writeUserInfo } from "@/app/actions/user/writeUserInfo";
+import {
+  ContactInfoData,
+  contactInfoSchema,
+} from "@/app/form-schemas/contact-info";
+import {
+  EventRegistrationData,
+  eventRegistrationSchema,
+} from "@/app/form-schemas/event-registration";
+import {
+  ProfessionalInfoData,
+  professionalInfoSchema,
+} from "@/app/form-schemas/professional-info";
+import { EventRegistrationWithSlot } from "@/app/types/EventRegistration";
+import { EventSlot } from "@/app/types/EventSlot";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { ContactInfoStep } from "@/components/user/ContactInfoStep";
+import { ProfessionalInfoStep } from "@/components/user/ProfessionalInfoStep";
+import {
+  type UserIndustryExperience,
+  type UserInfo,
+} from "@/drizzle/schema/user";
+import { useAuth } from "@/hooks/useAuth"; // Import the new hook
+import { useFormUserId } from "@/hooks/useFormUserId";
+import { cn } from "@/lib/utils";
+import { zodResolver } from "@hookform/resolvers/zod";
+import React, { useEffect, useState } from "react";
+import { FormProvider, useForm, UseFormReturn } from "react-hook-form";
+import { ConfirmationPage } from "./ConfirmationPage";
+import { ConfirmationStep } from "./ConfirmationStep";
+import { DateSelectionStep } from "./DateSelectionStep";
+import { EmailExistedStep } from "./EmailExistedStep";
+import { checkExistingRegistration, createRegistration } from "./actions";
+import { FormData, formSchema } from "./formSchema";
 
 interface RegistrationFormProps {
-  initialEventSlots: EventSlot[]
+  initialEventSlots: EventSlot[];
 }
 
-type FormContextType = UseFormReturn<ContactInfoData & ProfessionalInfoData & EventRegistrationData>;
+type FormContextType = UseFormReturn<
+  ContactInfoData & ProfessionalInfoData & EventRegistrationData
+>;
 
-export default function RegistrationForm({ initialEventSlots }: RegistrationFormProps) {
+export default function RegistrationForm({
+  initialEventSlots,
+}: RegistrationFormProps) {
   // Auth
   const { user, isLoading, error: authError, isAnonymous } = useAuth();
-  const { resolveFormUserId, userData, isLoading: isUserDataLoading } = useFormUserId();
+  const {
+    resolveFormUserId,
+    userData,
+    isLoading: isUserDataLoading,
+  } = useFormUserId();
   // States
   const [formStep, setFormStep] = useState(0);
   const [submitted, setSubmitted] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
   // Forms
-  const [registrationStatus, setRegistrationStatus] = useState<'pending' | 'confirmed' | 'checked-in' | 'cancelled'>('pending');
-  const [existingRegistration, setExistingRegistration] = useState<EventRegistrationWithSlot | null>(null);
+  const [registrationStatus, setRegistrationStatus] = useState<
+    "pending" | "confirmed" | "checked-in" | "cancelled"
+  >("pending");
+  const [existingRegistration, setExistingRegistration] =
+    useState<EventRegistrationWithSlot | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
   // Form setup
   const contactInfoForm = useForm<ContactInfoData>({
     resolver: zodResolver(contactInfoSchema),
-    mode: 'onSubmit', 
+    mode: "onSubmit",
     defaultValues: {
-      email: '',
-      firstName: '',
-      lastName: '',
-      phoneCountryCode: '84',
-      phoneNumber: '',
-      phoneCountryAlpha3: 'VNM',
+      email: "",
+      firstName: "",
+      lastName: "",
+      phoneCountryCode: "84",
+      phoneNumber: "",
+      phoneCountryAlpha3: "VNM",
     },
-  })
+  });
 
   const eventRegistrationForm = useForm<EventRegistrationData>({
     resolver: zodResolver(eventRegistrationSchema),
-    mode: 'onSubmit',
+    mode: "onSubmit",
     defaultValues: {
-      slot: '',
+      slot: "",
     },
-  })
+  });
 
   const professionalInfoForm = useForm<ProfessionalInfoData>({
     resolver: zodResolver(professionalInfoSchema),
-    mode: 'onSubmit',
+    mode: "onSubmit",
     defaultValues: {
-      industries: [],
-      experience: undefined,
+      industryExperiences: [],
     },
-  })
+  });
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
-    mode: 'onSubmit',
+    mode: "onSubmit",
     defaultValues: {
       // Contact Info
-      email: '',
-      firstName: '',
-      lastName: '',
-      phoneCountryCode: '84',
-      phoneNumber: '',
-      phoneCountryAlpha3: 'VNM',
+      email: "",
+      firstName: "",
+      lastName: "",
+      phoneCountryCode: "84",
+      phoneNumber: "",
+      phoneCountryAlpha3: "VNM",
 
       // Professional Info
-      industries: [],
-      experience: undefined,
+      industryExperiences: [],
 
       // Event Registration
-      slot: '',
-    }
-  })
-  
+      slot: "",
+    },
+  });
+
   // Effects
   useEffect(() => {
     if (userData && !isLoading) {
       // Auto-fill form fields
       contactInfoForm.reset({
         email: userData.email,
-        firstName: userData.firstName ?? '',
-        lastName: userData.lastName ?? '',
-        phoneCountryCode: userData.phoneCountryCode ?? '84',
-        phoneNumber: userData.phoneNumber ?? '',
-        phoneCountryAlpha3: userData.phoneCountryAlpha3 ?? 'VNM',
+        firstName: userData.firstName ?? "",
+        lastName: userData.lastName ?? "",
+        phoneCountryCode: userData.phoneCountryCode ?? "84",
+        phoneNumber: userData.phoneNumber ?? "",
+        phoneCountryAlpha3: userData.phoneCountryAlpha3 ?? "VNM",
       });
       professionalInfoForm.reset({
-        industries: userData.industries || [],
-        experience: userData.experience || undefined,
+        industryExperiences: userData.industryExperiences || [],
       });
     }
   }, [userData, isLoading, professionalInfoForm, contactInfoForm]);
 
   // Update this function to sync professionalInfo state with the form
-  const updateProfessionalInfo = (data: ProfessionalInfoData) => {
-    console.debug('Updating professionalInfoForm values to:', data)
-    professionalInfoForm.reset(data) // Reset the form with new data
-  }
+  const updateProfessionalInfo = (
+    userInfo: UserInfo,
+    industryExperiences?: UserIndustryExperience[],
+  ) => {
+    // Map the data to the new structure
+    const professionalData: ProfessionalInfoData = {
+      industryExperiences:
+        industryExperiences?.map((exp) => ({
+          industry: exp.industry,
+          experienceLevel: exp.experienceLevel,
+        })) || [],
+      // ... map other fields from userInfo
+    };
+
+    // Update your form state
+    professionalInfoForm.reset(professionalData);
+  };
 
   const validateContactInfo = async () => {
-    const result = await contactInfoForm.trigger()
-    console.log('Form validation result:', result)
+    const result = await contactInfoForm.trigger();
+    console.log("Form validation result:", result);
     if (!result) {
-      console.error('Form validation errors:', contactInfoForm.formState.errors)
+      console.error(
+        "Form validation errors:",
+        contactInfoForm.formState.errors,
+      );
     }
-    return result
-  }
+    return result;
+  };
 
   const validateEventRegistration = async () => {
-    const result = await eventRegistrationForm.trigger()
-    console.log('Event registration form validation result:', result)
+    const result = await eventRegistrationForm.trigger();
+    console.log("Event registration form validation result:", result);
     if (!result) {
-      console.error('Event registration form validation errors:', eventRegistrationForm.formState.errors)
+      console.error(
+        "Event registration form validation errors:",
+        eventRegistrationForm.formState.errors,
+      );
     }
-    return result
-  }
+    return result;
+  };
 
   const validateProfessionalInfo = async () => {
-    const result = await professionalInfoForm.trigger()
-    console.log('Professional info validation result:', result)
+    const result = await professionalInfoForm.trigger();
+    console.log("Professional info validation result:", result);
     if (!result) {
-      console.error('Professional info validation errors:', professionalInfoForm.formState.errors)
+      console.error(
+        "Professional info validation errors:",
+        professionalInfoForm.formState.errors,
+      );
     }
-    return result
-  }
-
+    return result;
+  };
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -169,87 +206,96 @@ export default function RegistrationForm({ initialEventSlots }: RegistrationForm
 
   const steps = [
     {
-      title: 'Contact Information',
-      description: 'Please provide your contact information',
+      title: "Contact Information",
+      description: "Please provide your contact information",
       component: <ContactInfoStep form={contactInfoForm} />,
       form: contactInfoForm,
-      fields: ['email', 'firstName', 'lastName', 'phone'] as const,
+      fields: ["email", "firstName", "lastName", "phone"] as const,
     },
     {
-      title: 'Professional Information',
-      description: 'Please provide your professional information',
+      title: "Professional Information",
+      description: "Please provide your professional information",
       component: <ProfessionalInfoStep form={professionalInfoForm} />,
       form: professionalInfoForm,
-      fields: [
-        'industries',
-        'experience',
-      ] as const,
+      fields: ["industryExperiences"] as const,
     },
     {
-      title: 'Select A Date',
-      description: 'Please select a slot for the event.',
-      component: <DateSelectionStep eventRegistrationForm={eventRegistrationForm} slots={initialEventSlots} />,
+      title: "Select A Date",
+      description: "Please select a slot for the event.",
+      component: (
+        <DateSelectionStep
+          eventRegistrationForm={eventRegistrationForm}
+          slots={initialEventSlots}
+        />
+      ),
       form: eventRegistrationForm,
-      fields: ['slot'] as const,
+      fields: ["slot"] as const,
     },
     {
-      title: 'Almost There!',
-      description: 'Please check if your information is correct.',
-      component: <ConfirmationStep
-        contactInfoData={contactInfoForm.getValues()}
-        eventRegistrationData={eventRegistrationForm.getValues()}
-        professionalInfoData={professionalInfoForm.getValues()}
-        slots={initialEventSlots}
-      />,
+      title: "Almost There!",
+      description: "Please check if your information is correct.",
+      component: (
+        <ConfirmationStep
+          contactInfoData={contactInfoForm.getValues()}
+          eventRegistrationData={eventRegistrationForm.getValues()}
+          professionalInfoData={professionalInfoForm.getValues()}
+          slots={initialEventSlots}
+        />
+      ),
       form: form,
       fields: [] as const,
     },
-  ]
+  ];
 
   // Extract the current step
-  const currentStep = steps[formStep]
+  const currentStep = steps[formStep];
   // Calculate progress percentage
-  const progress = ((formStep + 1) / steps.length) * 100
+  const progress = ((formStep + 1) / steps.length) * 100;
 
   const validateStep = async (step: number) => {
-    const form = steps[step].form
-    const result = await form.trigger()
-    return result
-  }
+    const form = steps[step].form;
+    const result = await form.trigger();
+    return result;
+  };
 
-  const handleNextStep = async (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    e.preventDefault()
-    const isStepValid = await validateStep(formStep)
+  const handleNextStep = async (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+  ) => {
+    e.preventDefault();
+    const isStepValid = await validateStep(formStep);
     if (isStepValid) {
       if (formStep === 0) {
         // Check for existing registration after email is entered
-        const email = contactInfoForm.getValues('email')
-        const { registration: existingRegistration, userInfo: existingUserInfo } = await checkExistingRegistration(email)
+        const email = contactInfoForm.getValues("email");
+        const {
+          registration: existingRegistration,
+          userInfo: existingUserInfo,
+        } = await checkExistingRegistration(email);
         if (existingRegistration) {
-          setExistingRegistration(existingRegistration)
+          setExistingRegistration(existingRegistration);
         }
         if (existingUserInfo) {
-          updateProfessionalInfo(existingUserInfo as ProfessionalInfoData)
+          updateProfessionalInfo(existingUserInfo as UserInfo);
         }
         // return // Don't proceed to next step yet
       }
-      setFormStep((prev) => Math.min(steps.length - 1, prev + 1))
+      setFormStep((prev) => Math.min(steps.length - 1, prev + 1));
     } else {
       // Merge errors from all forms
       const formErrors = {
         ...contactInfoForm.formState.errors,
         ...eventRegistrationForm.formState.errors,
         ...professionalInfoForm.formState.errors,
-      }
-      console.log('Validation failed:', formErrors)
+      };
+      console.log("Validation failed:", formErrors);
     }
-  }
+  };
 
   const handleConfirmNewRegistration = () => {
     setIsUpdating(true);
     setExistingRegistration(null);
     setFormStep(1); // Move to date selection step
-  }
+  };
 
   const handleKeepExistingRegistration = () => {
     setExistingRegistration(null);
@@ -258,47 +304,62 @@ export default function RegistrationForm({ initialEventSlots }: RegistrationForm
     contactInfoForm.reset();
     eventRegistrationForm.reset();
     professionalInfoForm.reset();
-  }
+  };
 
-  const handleSubmit = async (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    e.preventDefault()
-    console.debug('Submit button clicked')
-    console.debug('Current contact:', contactInfoForm.getValues())
-    console.debug('Current professional info:', professionalInfoForm.getValues())
-    console.debug('isUpdating:', isUpdating)
-    console.debug('isSubmitting:', isSubmitting)
+  const handleSubmit = async (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+  ) => {
+    e.preventDefault();
+    console.debug("Submit button clicked");
+    console.debug("Current contact:", contactInfoForm.getValues());
+    console.debug(
+      "Current professional info:",
+      professionalInfoForm.getValues(),
+    );
+    console.debug("isUpdating:", isUpdating);
+    console.debug("isSubmitting:", isSubmitting);
 
     if (isSubmitting) {
-      console.log('Form is already submitting, returning early')
-      return
+      console.log("Form is already submitting, returning early");
+      return;
     }
 
-    setIsSubmitting(true)
-    setFormError(null)
+    setIsSubmitting(true);
+    setFormError(null);
 
     try {
-      const isContactInfoValid = await validateContactInfo()
-      const isEventRegistrationValid = await validateEventRegistration()
-      const isProfessionalInfoValid = validateProfessionalInfo()
+      const isContactInfoValid = await validateContactInfo();
+      const isEventRegistrationValid = await validateEventRegistration();
+      const isProfessionalInfoValid = validateProfessionalInfo();
 
-      console.log('Contact info validation result:', isContactInfoValid)
-      console.log('Event registration validation result:', isEventRegistrationValid)
-      console.log('Professional info validation result:', isProfessionalInfoValid)
+      console.log("Contact info validation result:", isContactInfoValid);
+      console.log(
+        "Event registration validation result:",
+        isEventRegistrationValid,
+      );
+      console.log(
+        "Professional info validation result:",
+        isProfessionalInfoValid,
+      );
 
-      if (!isContactInfoValid || !isEventRegistrationValid || !isProfessionalInfoValid) {
-        console.error('Form validation failed')
-        setIsSubmitting(false)
-        return
+      if (
+        !isContactInfoValid ||
+        !isEventRegistrationValid ||
+        !isProfessionalInfoValid
+      ) {
+        console.error("Form validation failed");
+        setIsSubmitting(false);
+        return;
       }
 
-      const contactInfoData = contactInfoForm.getValues()
-      const eventRegistrationData = eventRegistrationForm.getValues()
-      const professionalInfoData = professionalInfoForm.getValues()
+      const contactInfoData = contactInfoForm.getValues();
+      const eventRegistrationData = eventRegistrationForm.getValues();
+      const professionalInfoData = professionalInfoForm.getValues();
       const combinedData = {
         ...contactInfoData,
         ...eventRegistrationData,
         ...professionalInfoData,
-      }
+      };
 
       // Either:
       // - formData.email is a confirmed email address (getUserId is not null)
@@ -306,59 +367,70 @@ export default function RegistrationForm({ initialEventSlots }: RegistrationForm
       // - user is logged-in anonymously (a user is already created via signInAnonymously)
       const formUserId = await resolveFormUserId(contactInfoData.email);
 
-      console.log('Combined data for submission:', combinedData)
+      console.log("Combined data for submission:", combinedData);
 
       const [registrationResult, userInfoResult] = await Promise.all([
         createRegistration({
-          ...combinedData,
+          // Contact Info & Social Media
+          ...contactInfoData,
+
+          // Event Registration
+          slot: eventRegistrationData.slot,
+
+          // Professional Info
+          ...professionalInfoData,
+
+          // Additional fields
           created_by: user?.id || null,
           is_anonymous: isAnonymous,
-          existingRegistrationId: isUpdating ? existingRegistration?.id : undefined,
+          existingRegistrationId: isUpdating
+            ? existingRegistration?.id
+            : undefined,
         }),
-        formUserId && combinedData.industries && combinedData.experience
+        formUserId && combinedData.industryExperiences
           ? writeUserInfo(
-            formUserId,
-            {
-              phoneCountryCode: contactInfoData.phoneCountryCode,
-              phoneNumber: contactInfoData.phoneNumber,
-              phoneCountryAlpha3: contactInfoData.phoneCountryAlpha3,
-              firstName: contactInfoData.firstName,
-              lastName: contactInfoData.lastName,
-            },
-            {
-              industries: combinedData.industries as IndustryType[],
-              experience: combinedData.experience as ExperienceType,
-            },
-            {
-              instagramHandle: combinedData.instagramHandle,
-              facebookHandle: combinedData.facebookHandle,
-            }
-          )
+              formUserId,
+              {
+                phoneCountryCode: contactInfoData.phoneCountryCode,
+                phoneNumber: contactInfoData.phoneNumber,
+                phoneCountryAlpha3: contactInfoData.phoneCountryAlpha3,
+                firstName: contactInfoData.firstName,
+                lastName: contactInfoData.lastName,
+              },
+              professionalInfoData,
+              {
+                instagramHandle: combinedData.instagramHandle,
+                facebookHandle: combinedData.facebookHandle,
+              },
+            )
           : Promise.resolve(null),
-      ])
+      ]);
 
-      console.log('Registration result:', registrationResult)
-      console.log('User info result:', userInfoResult)
+      console.log("Registration result:", registrationResult);
+      console.log("User info result:", userInfoResult);
 
       if (registrationResult.success) {
-        setSubmitted(true)
-        setRegistrationStatus(registrationResult.status)
+        setSubmitted(true);
+        setRegistrationStatus(registrationResult.status);
       } else {
-        throw new Error(registrationResult.error || 'Registration failed')
+        throw new Error(registrationResult.error || "Registration failed");
       }
 
       if (userInfoResult && !userInfoResult.success) {
-        console.error('Error writing user info:', userInfoResult.error)
+        console.error("Error writing user info:", userInfoResult.error);
       }
     } catch (error) {
-      console.error('Error during registration:', error)
-      setFormError(error instanceof Error ? error.message : 'An unexpected error occurred during registration')
+      console.error("Error during registration:", error);
+      setFormError(
+        error instanceof Error
+          ? error.message
+          : "An unexpected error occurred during registration",
+      );
     } finally {
-      setIsSubmitting(false)
-      setIsUpdating(false)
+      setIsSubmitting(false);
+      setIsUpdating(false);
     }
-  }
-
+  };
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -374,41 +446,55 @@ export default function RegistrationForm({ initialEventSlots }: RegistrationForm
   }
 
   if (submitted) {
-    return <ConfirmationPage
-      contactInfoData={contactInfoForm.getValues()}
-      eventRegistrationData={eventRegistrationForm.getValues()}
-      professionalInfoData={professionalInfoForm.getValues()}
-      slots={initialEventSlots}
-      status={registrationStatus}
-    />
+    return (
+      <ConfirmationPage
+        contactInfoData={contactInfoForm.getValues()}
+        eventRegistrationData={eventRegistrationForm.getValues()}
+        professionalInfoData={professionalInfoForm.getValues()}
+        slots={initialEventSlots}
+        status={registrationStatus}
+      />
+    );
   }
 
   if (existingRegistration) {
-    return <EmailExistedStep
-      existingRegistration={existingRegistration as EventRegistrationWithSlot}
-      onConfirm={handleConfirmNewRegistration}
-      onCancel={handleKeepExistingRegistration}
-    />
+    return (
+      <EmailExistedStep
+        existingRegistration={existingRegistration as EventRegistrationWithSlot}
+        onConfirm={handleConfirmNewRegistration}
+        onCancel={handleKeepExistingRegistration}
+      />
+    );
   }
 
   return (
-    <FormProvider {...currentStep.form as FormContextType}>
-      <form onSubmit={(e) => e.preventDefault()} className={cn('flex flex-col gap-2')}>
+    <FormProvider {...(currentStep.form as FormContextType)}>
+      <form
+        onSubmit={(e) => e.preventDefault()}
+        className={cn("flex flex-col gap-2")}
+      >
         <div
-          className={cn('flex flex-col space-y-2 p-4 bg-slate-400 bg-opacity-10 rounded-md border border-primary-foreground border-opacity-20')}
-          style={{ backgroundColor: '#F6EBE4' }}
+          className={cn(
+            "flex flex-col space-y-2 rounded-md border border-primary-foreground border-opacity-20 bg-slate-400 bg-opacity-10 p-4",
+          )}
+          style={{ backgroundColor: "#F6EBE4" }}
         >
-          <h2 className="text-2xl font-semibold text-primary">{currentStep.title}</h2>
+          <h2 className="text-2xl font-semibold text-primary">
+            {currentStep.title}
+          </h2>
           <p>{currentStep.description}</p>
           <div>
-            <p className="text-muted-foreground text-sm">
-              {isLoading ? 'Loading user information...' : `You're ` + (user?.email ? `logged in as ${user.email}` : `a guest`)}
+            <p className="text-sm text-muted-foreground">
+              {isLoading
+                ? "Loading user information..."
+                : `You're ` +
+                  (user?.email ? `logged in as ${user.email}` : `a guest`)}
             </p>
           </div>
           <Progress value={progress} className="w-full" />
         </div>
         {currentStep.component}
-        <div className="flex flex-col sm:flex-row justify-between mt-2 gap-2">
+        <div className="mt-2 flex flex-col justify-between gap-2 sm:flex-row">
           <Button
             type="button"
             onClick={() => setFormStep((prev) => Math.max(0, prev - 1))}
@@ -433,16 +519,20 @@ export default function RegistrationForm({ initialEventSlots }: RegistrationForm
               disabled={isSubmitting}
               className="w-full sm:w-auto"
             >
-              {isSubmitting ? 'Submitting...' : isUpdating ? 'Update' : 'Submit'}
+              {isSubmitting
+                ? "Submitting..."
+                : isUpdating
+                  ? "Update"
+                  : "Submit"}
             </Button>
           )}
         </div>
         {formError && (
-          <div className="error-message mt-2 text-red-500 text-sm">
+          <div className="error-message mt-2 text-sm text-red-500">
             {formError}
           </div>
         )}
       </form>
     </FormProvider>
-  )
+  );
 }

--- a/app/(public)/(event)/register/_sections/formSchema.ts
+++ b/app/(public)/(event)/register/_sections/formSchema.ts
@@ -1,9 +1,12 @@
 // File: app/(public)/(event)/register/_sections/formSchema.ts
 
-import { ContactInfoData, contactInfoSchema } from "@/app/form-schemas/contact-info";
-import { EventRegistrationData, eventRegistrationSchema } from "@/app/form-schemas/event-registration";
-import { ProfessionalInfoData, professionalInfoSchema } from "@/app/form-schemas/professional-info";
+import { z } from 'zod'
+import { contactInfoSchema } from '@/app/form-schemas/contact-info'
+import { eventRegistrationSchema } from '@/app/form-schemas/event-registration'
+import { professionalInfoSchema } from '@/app/form-schemas/professional-info'
 
-export const formSchema = contactInfoSchema.merge(eventRegistrationSchema).merge(professionalInfoSchema);
+export const formSchema = contactInfoSchema
+  .merge(eventRegistrationSchema)
+  .merge(professionalInfoSchema)
 
-export type FormData = ContactInfoData & EventRegistrationData & ProfessionalInfoData;
+export type FormData = z.infer<typeof formSchema>

--- a/app/(public)/(event)/register/_sections/types.ts
+++ b/app/(public)/(event)/register/_sections/types.ts
@@ -1,43 +1,38 @@
 // File: app/(public)/(event)/register/_sections/types.ts
+import { InferSelectModel } from "drizzle-orm";
+import { eventRegistrations, eventSlots } from "@/drizzle/schema/event";
+import { IndustryType, ExperienceType } from "@/drizzle/schema/user";
 
-interface EventSlot {
-	id: string
-	created_at: string
-	time_start: string
-	time_end: string
-	capacity: number
-}
-
-export interface EventRegistration {
-	id: string
-	slot: string
-	created_at: string
-	created_by: string
-	signature: string
-	status: 'confirmed' | 'pending' | 'checked-in' | 'cancelled'
-}
+// Use schema types directly
+export type EventSlot = InferSelectModel<typeof eventSlots>;
+export type EventRegistration = InferSelectModel<typeof eventRegistrations>;
 
 export type FormData = {
-	// Contact Info
-	email: string
-	firstName: string
-	lastName: string
-	phoneCountryCode: string
-	phoneNumber: string
-	phoneCountryAlpha3: string
+  // Contact Info
+  email: string;
+  firstName: string;
+  lastName: string;
+  phoneCountryCode: string;
+  phoneNumber: string;
+  phoneCountryAlpha3: string;
 
-	// Professional Info
-	industries: string[]
-	experience: string
+  // Professional Info
+  industryExperiences: {
+    industry: IndustryType;
+    experienceLevel: ExperienceType;
+  }[];
 
-	// Event Registration
-	slot: string
+  // Event Registration
+  slot: string;
 
-	// Social Media
-	instagramHandle?: string
-	facebookHandle?: string
+  // Social Media
+  instagramHandle?: string;
+  facebookHandle?: string;
 }
 
 export interface EventRegistrationWithSlot extends EventRegistration {
-	event_slot: EventSlot
+  event_slot: EventSlot;
+  slot_time_start: string;
+  slot_time_end: string;
+  slot_details: EventSlot;
 }

--- a/app/(public)/(event)/register/types.ts
+++ b/app/(public)/(event)/register/types.ts
@@ -1,0 +1,8 @@
+import { IndustryType, ExperienceType } from '@/drizzle/schema/user';
+
+export interface ProfessionalInfoData {
+  industryExperiences: {
+    industry: IndustryType;
+    experienceLevel: ExperienceType;
+  }[];
+} 

--- a/app/(public)/event/[eventSlug]/upload/UploadPageClient.tsx
+++ b/app/(public)/event/[eventSlug]/upload/UploadPageClient.tsx
@@ -152,8 +152,7 @@ function UploadPageContent({
     resolver: zodResolver(professionalInfoSchema),
     mode: "onSubmit",
     defaultValues: {
-      industries: [],
-      experience: undefined,
+      industryExperiences: [],
     },
   });
 
@@ -178,7 +177,6 @@ function UploadPageContent({
   // Effects
   useEffect(() => {
     if (userData && !isLoading) {
-      // Auto-fill form fields
       contactInfoForm.reset({
         email: userData.email,
         firstName: userData.firstName ?? '',
@@ -188,9 +186,14 @@ function UploadPageContent({
         instagramHandle: userData.instagramHandle || undefined,
         facebookHandle: userData.facebookHandle || undefined,
       });
+      
+      const industryExperiences = userData.industryExperiences?.map(exp => ({
+        industry: exp.industry,
+        experienceLevel: exp.experienceLevel
+      })) || [];
+      
       professionalInfoForm.reset({
-        industries: userData.industries || [],
-        experience: userData.experience || undefined,
+        industryExperiences
       });
     }
   }, [userData, isLoading, professionalInfoForm, contactInfoForm]);

--- a/app/(public)/event/[eventSlug]/upload/client-helpers.ts
+++ b/app/(public)/event/[eventSlug]/upload/client-helpers.ts
@@ -30,8 +30,7 @@ export async function handleUserInfo(
       lastName: contactInfoData.lastName,
     },
     {
-      industries: professionalInfoData.industries as Industry[],
-      experience: professionalInfoData.experience as ExperienceLevel | null,
+      industryExperiences: professionalInfoData.industryExperiences
     },
     {
       instagramHandle: contactInfoData.instagramHandle,
@@ -91,8 +90,7 @@ export async function handleCoArtists(artworkData: ArtworkInfoData, artworkCredi
         lastName: coartist.last_name,
       },
       {
-        industries: [],
-        experience: null,
+        industryExperiences: []
       },
       {
         instagramHandle: undefined,

--- a/app/actions/user/writeUserInfo.ts
+++ b/app/actions/user/writeUserInfo.ts
@@ -1,8 +1,9 @@
 "use server";
 
-import { IndustryType, ExperienceType, userInfos } from "@/drizzle/schema/user";
+import { IndustryType, ExperienceType, userInfos, userIndustryExperience } from "@/drizzle/schema/user";
 import { db } from "@/lib/db";
 import { getDisplayName } from "@/lib/name";
+import { eq } from "drizzle-orm";
 
 export async function writeUserInfo(
   userId: string,
@@ -16,8 +17,10 @@ export async function writeUserInfo(
     userName?: string;
   },
   professionalInfo: {
-    industries: IndustryType[];
-    experience: ExperienceType | null;
+    industryExperiences: {
+      industry: IndustryType;
+      experienceLevel: ExperienceType;
+    }[];
   },
   socialInfo: {
     instagramHandle?: string;
@@ -27,13 +30,10 @@ export async function writeUserInfo(
   validateUserInfo: boolean = true,
 ) {
   console.log("Received professionalInfo:", professionalInfo);
+  
   // Validate professional info
   if (validateProfessionalInfo) {
-    if (
-      !professionalInfo.industries ||
-      professionalInfo.industries.length === 0 ||
-      !professionalInfo.experience
-    ) {
+    if (!professionalInfo.industryExperiences || professionalInfo.industryExperiences.length === 0) {
       console.error("Invalid professional info:", professionalInfo);
       return { success: false, error: "Invalid professional info" };
     }
@@ -57,27 +57,49 @@ export async function writeUserInfo(
       displayName: getDisplayName(userInfo.firstName, userInfo.lastName, true),
       instagramHandle: socialInfo.instagramHandle,
       facebookHandle: socialInfo.facebookHandle,
-      industries: professionalInfo.industries,
-      experience: professionalInfo.experience,
     };
 
     console.log("writeUserInfo updating with:", updateSet);
 
-    const result = await db
-      .insert(userInfos)
-      .values({
-        id: userId,
-        ...updateSet,
-      })
-      .onConflictDoUpdate({
-        target: userInfos.id,
-        set: updateSet,
-      })
-      .returning();
+    // Use a transaction to update both user info and industry experiences
+    const result = await db.transaction(async (tx) => {
+      // Update user info
+      const userInfoResult = await tx
+        .insert(userInfos)
+        .values({
+          id: userId,
+          ...updateSet,
+        })
+        .onConflictDoUpdate({
+          target: userInfos.id,
+          set: updateSet,
+        })
+        .returning();
+
+      // Delete existing industry experiences
+      await tx
+        .delete(userIndustryExperience)
+        .where(eq(userIndustryExperience.userId, userId));
+
+      // Insert new industry experiences
+      if (professionalInfo.industryExperiences.length > 0) {
+        await tx
+          .insert(userIndustryExperience)
+          .values(
+            professionalInfo.industryExperiences.map(exp => ({
+              userId,
+              industry: exp.industry,
+              experienceLevel: exp.experienceLevel,
+            }))
+          );
+      }
+
+      return userInfoResult[0];
+    });
 
     console.log("writeUserInfo update result:", result);
 
-    return { success: true, data: result[0] };
+    return { success: true, data: result };
   } catch (error) {
     console.error("writeUserInfo error writing user info:", error);
     return { success: false, error: (error as Error).message };

--- a/app/api/user/helper.ts
+++ b/app/api/user/helper.ts
@@ -1,21 +1,21 @@
 import { UserData } from "@/app/types/UserInfo";
-import { PortfolioArtwork } from "@/drizzle/schema/portfolio";
 
 export async function fetchUserData(userId: string): Promise<UserData | null> {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ||
-    (typeof window !== 'undefined' ? window.location.origin : '');
+  const baseUrl =
+    process.env.NEXT_PUBLIC_APP_URL ||
+    (typeof window !== "undefined" ? window.location.origin : "");
 
   // Construct the full URL
   const url = `${baseUrl}/api/user/${userId}`;
 
   const response = await fetch(url, {
-    method: 'GET',
+    method: "GET",
     headers: {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
     },
   });
   if (!response.ok) {
-    throw new Error('Failed to fetch user data');
+    throw new Error("Failed to fetch user data");
   }
   return response.json();
 }

--- a/app/form-schemas/about-info.ts
+++ b/app/form-schemas/about-info.ts
@@ -6,6 +6,7 @@ export { contactInfoSchema, professionalInfoSchema }
 
 export const aboutSchema = z.object({
   about: z.string().optional(),
+  ...professionalInfoSchema.shape
 })
 
 export type AboutInfoData = z.infer<typeof aboutSchema>

--- a/app/form-schemas/professional-info.ts
+++ b/app/form-schemas/professional-info.ts
@@ -1,12 +1,12 @@
-// File: app/(public)/(event)/register/_sections/formSchema.ts
-
 import { z } from "zod";
 import { industries, experienceLevels } from "@/drizzle/schema/user";
 
-// Define the schema for ProfessionalInfoStep
+// Define the schema for professional info form
 export const professionalInfoSchema = z.object({
-  industries: z.array(z.enum(industries)).min(1, { message: "Please select at least one industry" }),
-  experience: z.enum(experienceLevels),
-})
+  industryExperiences: z.array(z.object({
+    industry: z.enum(industries),
+    experienceLevel: z.enum(experienceLevels)
+  })).min(1, { message: "Please add at least one industry experience" })
+});
 
-export type ProfessionalInfoData = z.infer<typeof professionalInfoSchema>
+export type ProfessionalInfoData = z.infer<typeof professionalInfoSchema>;

--- a/app/types/UserInfo.tsx
+++ b/app/types/UserInfo.tsx
@@ -1,16 +1,32 @@
 // File: app/types/UserInfo.tsx
-
-import { IndustryType, ExperienceType, UserInfo as DrizzleUserInfo } from '@/drizzle/schema/user';
+import {
+  IndustryType,
+  ExperienceType,
+  UserInfo as DrizzleUserInfo,
+  UserIndustryExperience,
+} from "@/drizzle/schema/user";
 
 export type Industry = IndustryType;
 export type ExperienceLevel = ExperienceType;
-
 export type UserInfo = DrizzleUserInfo;
 
-export interface UserData extends Omit<DrizzleUserInfo, 'experience'> {
+export interface UserData extends Omit<DrizzleUserInfo, "experience"> {
+  id: string;
   email: string;
+  firstName: string;
+  lastName: string;
+  userName: string;
+  displayName: string;
+  phoneCountryCode: string;
+  phoneNumber: string;
+  phoneCountryAlpha3: string;
   isAnonymous: boolean;
   emailConfirmedAt: Date | null;
-  industries: Industry[];
-  experience: ExperienceLevel | null;
+  location: string | null;
+  occupation: string | null;
+  about: string | null;
+  profilePicture: string | null;
+  instagramHandle: string | null;
+  facebookHandle: string | null;
+  industryExperiences: UserIndustryExperience[];
 }

--- a/components/contacts/ContactCard.tsx
+++ b/components/contacts/ContactCard.tsx
@@ -4,7 +4,8 @@ import { UserData } from "@/app/types/UserInfo";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { useTranslation } from "@/lib/i18n/init-client";
-import { Briefcase, CheckCircle, MapPin, TrendingUp, UserCircle } from 'lucide-react';
+import { Briefcase, CheckCircle, MapPin, UserCircle } from 'lucide-react';
+import { ComboBadge } from "@/components/ui/combo-badge";
 
 interface ContactCardProps {
   userData: UserData;
@@ -47,22 +48,22 @@ export function ContactCard({
         </div>
       </CardHeader>
 
-      <CardContent className="flex-grow p-4">
+        <CardContent className="flex-grow p-4">
         <ul className="space-y-3">
-          {userData.industries && userData.industries.length > 0 && (
+          {userData.industryExperiences && userData.industryExperiences.length > 0 && (
             <li className="flex items-center">
               <Briefcase className="mr-2 h-4 w-4 flex-shrink-0" />
               <div className="flex flex-wrap gap-2">
-                {userData.industries.map((industry, index) => (
-                  <Badge key={index} variant="secondary">{industry}</Badge>
+                {userData.industryExperiences.map((exp, index) => (
+                  <ComboBadge
+                    key={index}
+                    leftContent={exp.industry}
+                    rightContent={exp.experienceLevel}
+                    leftColor="bg-primary"
+                    rightColor="bg-secondary"
+                  />
                 ))}
               </div>
-            </li>
-          )}
-          {userData.experience && (
-            <li className="flex items-center">
-              <TrendingUp className="mr-2 h-4 w-4 flex-shrink-0" />
-              <span>{userData.experience}</span>
             </li>
           )}
           {userData.location && (

--- a/components/contacts/ContactCard.tsx
+++ b/components/contacts/ContactCard.tsx
@@ -60,7 +60,7 @@ export function ContactCard({
                     leftContent={exp.industry}
                     rightContent={exp.experienceLevel}
                     leftColor="bg-primary"
-                    rightColor="bg-secondary"
+                    rightColor="bg-primary/80"
                   />
                 ))}
               </div>

--- a/components/contacts/ContactList.tsx
+++ b/components/contacts/ContactList.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { UserData } from "@/app/types/UserInfo";
+import { ContactCard } from "./ContactCard";
+import { EmptyContactCard } from "./EmptyContactCard";
+
+export function ContactList({ userId, lang }: { userId: string, lang: string }) {
+  const [contacts, setContacts] = useState<UserData[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function loadContacts() {
+      try {
+        const response = await fetch(`/api/user/${userId}/contacts`);
+        const data = await response.json();
+        setContacts(data);
+      } catch (error) {
+        console.error('Error loading contacts:', error);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadContacts();
+  }, [userId]);
+
+  if (loading) return <div>Loading...</div>;
+  
+  if (contacts.length === 0) {
+    return <EmptyContactCard lang={lang} />;
+  }
+
+  return contacts.map((contact) => (
+    <ContactCard
+      key={contact.id}
+      lang={lang}
+      userData={contact}
+      showButtons={false}
+    />
+  ));
+}

--- a/components/profile/ProfessionalSection.tsx
+++ b/components/profile/ProfessionalSection.tsx
@@ -4,9 +4,9 @@
 
 import { useFormState } from "@/app/(protected)/profile/edit/FormStateNav";
 import { ExperienceLevel, Industry, UserData } from "@/app/types/UserInfo";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ComboBadge } from "@/components/ui/combo-badge";
 import {
   Command,
   CommandEmpty,
@@ -198,9 +198,13 @@ export function ProfessionalSection({
             <Label>{t("ProfessionalSection.currentIndustries")}</Label>
             <div className="mt-2 flex flex-wrap gap-2">
               {selectedIndustryExperiences.map((ie) => (
-                <Badge key={ie.industry}>
-                  {ie.industry} - {ie.experienceLevel}
-                </Badge>
+                <ComboBadge
+                  key={ie.industry}
+                  leftContent={ie.industry}
+                  rightContent={ie.experienceLevel}
+                  leftColor="bg-primary"
+                  rightColor="bg-primary/80"
+                />
               ))}
             </div>
 
@@ -217,7 +221,7 @@ export function ProfessionalSection({
             ) : (
               <div className="mt-2 flex gap-2">
                 <div className="flex-1">
-                  <IndustryCombobox 
+                  <IndustryCombobox
                     value={newIndustry}
                     onChange={setNewIndustry}
                   />

--- a/components/profile/ProfessionalSection.tsx
+++ b/components/profile/ProfessionalSection.tsx
@@ -30,6 +30,110 @@ import { cn } from "@/lib/utils";
 import { Check, ChevronsUpDown, Plus } from "lucide-react";
 import { useEffect, useState } from "react";
 
+interface IndustryComboboxProps {
+  value: Industry | null;
+  onChange: (value: Industry) => void;
+}
+
+function IndustryCombobox({ value, onChange }: IndustryComboboxProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          className="w-full justify-between"
+        >
+          {value || "Select Industry"}
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+        <Command>
+          <CommandInput placeholder="Search industry..." />
+          <CommandList>
+            <CommandEmpty>No industry found</CommandEmpty>
+            <CommandGroup>
+              {industriesMapper.map((industry) => (
+                <CommandItem
+                  key={industry.value}
+                  value={industry.value}
+                  onSelect={() => {
+                    onChange(industry.value as Industry);
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      value === industry.value ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  {industry.label}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+interface ExperienceComboboxProps {
+  value: ExperienceLevel | null;
+  onChange: (value: ExperienceLevel) => void;
+}
+
+function ExperienceCombobox({ value, onChange }: ExperienceComboboxProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          className="w-full justify-between"
+        >
+          {value || "Select Experience"}
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+        <Command>
+          <CommandInput placeholder="Search experience level..." />
+          <CommandList>
+            <CommandEmpty>No experience level found</CommandEmpty>
+            <CommandGroup>
+              {experienceLevelsMapper.map((level) => (
+                <CommandItem
+                  key={level.value}
+                  value={level.value}
+                  onSelect={() => {
+                    onChange(level.value as ExperienceLevel);
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      value === level.value ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  {level.label}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
 interface ProfessionalSectionProps {
   userData: UserData;
   lang?: string;
@@ -113,93 +217,17 @@ export function ProfessionalSection({
             ) : (
               <div className="mt-2 flex gap-2">
                 <div className="flex-1">
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
-                        role="combobox"
-                        className="w-full justify-between"
-                      >
-                        {newIndustry || "Select Industry"}
-                        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
-                      <Command>
-                        <CommandInput placeholder="Search industry..." />
-                        <CommandList>
-                          <CommandEmpty>No industry found</CommandEmpty>
-                          <CommandGroup>
-                            {industriesMapper.map((industry) => (
-                              <CommandItem
-                                key={industry.value}
-                                value={industry.value}
-                                onSelect={() =>
-                                  setNewIndustry(industry.value as Industry)
-                                }
-                              >
-                                <Check
-                                  className={cn(
-                                    "mr-2 h-4 w-4",
-                                    newIndustry === industry.value
-                                      ? "opacity-100"
-                                      : "opacity-0",
-                                  )}
-                                />
-                                {industry.label}
-                              </CommandItem>
-                            ))}
-                          </CommandGroup>
-                        </CommandList>
-                      </Command>
-                    </PopoverContent>
-                  </Popover>
+                  <IndustryCombobox 
+                    value={newIndustry}
+                    onChange={setNewIndustry}
+                  />
                 </div>
 
                 <div className="flex-1">
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
-                        role="combobox"
-                        className="w-full justify-between"
-                      >
-                        {newExperience || "Select Experience"}
-                        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
-                      <Command>
-                        <CommandInput placeholder="Search experience level..." />
-                        <CommandList>
-                          <CommandEmpty>No experience level found</CommandEmpty>
-                          <CommandGroup>
-                            {experienceLevelsMapper.map((level) => (
-                              <CommandItem
-                                key={level.value}
-                                value={level.value}
-                                onSelect={() =>
-                                  setNewExperience(
-                                    level.value as ExperienceLevel,
-                                  )
-                                }
-                              >
-                                <Check
-                                  className={cn(
-                                    "mr-2 h-4 w-4",
-                                    newExperience === level.value
-                                      ? "opacity-100"
-                                      : "opacity-0",
-                                  )}
-                                />
-                                {level.label}
-                              </CommandItem>
-                            ))}
-                          </CommandGroup>
-                        </CommandList>
-                      </Command>
-                    </PopoverContent>
-                  </Popover>
+                  <ExperienceCombobox
+                    value={newExperience}
+                    onChange={setNewExperience}
+                  />
                 </div>
 
                 <Button

--- a/components/profile/ProfessionalSection.tsx
+++ b/components/profile/ProfessionalSection.tsx
@@ -1,179 +1,218 @@
+// File: components/profile/ProfessionalSection.tsx
+
 "use client";
 
-import { UserData, Industry, ExperienceLevel } from "@/app/types/UserInfo";
+import { useFormState } from "@/app/(protected)/profile/edit/FormStateNav";
+import { ExperienceLevel, Industry, UserData } from "@/app/types/UserInfo";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
 import { Label } from "@/components/ui/label";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { experienceLevelsMapper, industriesMapper } from "@/drizzle/schema/user";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  experienceLevelsMapper,
+  industriesMapper,
+} from "@/drizzle/schema/user";
+import { useTranslation } from "@/lib/i18n/init-client";
 import { cn } from "@/lib/utils";
-import { Check, ChevronsUpDown } from 'lucide-react';
-import { useState, useEffect } from "react";
-import { useFormState } from "@/app/(protected)/profile/edit/FormStateNav";
-import { useTranslation } from '@/lib/i18n/init-client'
+import { Check, ChevronsUpDown, Plus } from "lucide-react";
+import { useEffect, useState } from "react";
 
 interface ProfessionalSectionProps {
   userData: UserData;
   lang?: string;
 }
 
-export function ProfessionalSection({ userData, lang = "en" }: ProfessionalSectionProps) {
+export function ProfessionalSection({
+  userData,
+  lang = "en",
+}: ProfessionalSectionProps) {
   const { t } = useTranslation(lang, "ProfilePage");
-  const [selectedIndustryExperiences, setSelectedIndustryExperiences] = useState(
-    userData.industryExperiences || []
+  const [selectedIndustryExperiences, setSelectedIndustryExperiences] =
+    useState(userData.industryExperiences || []);
+  const [isAdding, setIsAdding] = useState(false);
+  const [newIndustry, setNewIndustry] = useState<Industry | null>(null);
+  const [newExperience, setNewExperience] = useState<ExperienceLevel | null>(
+    null,
   );
   const { setFieldDirty, setFormData } = useFormState();
 
   useEffect(() => {
-    const industryExperiencesChanged = JSON.stringify(selectedIndustryExperiences) !== 
+    const industryExperiencesChanged =
+      JSON.stringify(selectedIndustryExperiences) !==
       JSON.stringify(userData.industryExperiences || []);
-    
-    setFieldDirty('professional', industryExperiencesChanged);
-    
-    setFormData('professional', {
-      industryExperiences: selectedIndustryExperiences
-    });
-  }, [selectedIndustryExperiences, userData.industryExperiences, setFieldDirty, setFormData]);
 
-  const toggleIndustryExperience = (industry: Industry, experienceLevel: ExperienceLevel) => {
-    setSelectedIndustryExperiences(current => {
-      const exists = current.find(ie => ie.industry === industry);
-      if (exists) {
-        return current.filter(ie => ie.industry !== industry);
-      } else {
-        return [...current, { 
-          id: crypto.randomUUID(), 
-          userId: userData.id, 
-          industry, 
-          experienceLevel 
-        }];
-      }
+    setFieldDirty("professional", industryExperiencesChanged);
+
+    setFormData("professional", {
+      industryExperiences: selectedIndustryExperiences,
     });
+  }, [
+    selectedIndustryExperiences,
+    userData.industryExperiences,
+    setFieldDirty,
+    setFormData,
+  ]);
+
+  const addIndustryExperience = () => {
+    if (newIndustry && newExperience) {
+      setSelectedIndustryExperiences((current) => [
+        ...current,
+        {
+          id: crypto.randomUUID(),
+          userId: userData.id,
+          industry: newIndustry,
+          experienceLevel: newExperience,
+        },
+      ]);
+      setIsAdding(false);
+      setNewIndustry(null);
+      setNewExperience(null);
+    }
   };
 
   return (
     <Card id="professional">
       <CardHeader>
-        <CardTitle>{t('ProfessionalSection.professional')}</CardTitle>
+        <CardTitle>{t("ProfessionalSection.professional")}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="grid grid-cols-1 gap-6">
           <div className="space-y-2">
-            <Label>{t('ProfessionalSection.currentIndustries')}</Label>
-            <div className="flex flex-wrap gap-2 mt-2">
+            <Label>{t("ProfessionalSection.currentIndustries")}</Label>
+            <div className="mt-2 flex flex-wrap gap-2">
               {selectedIndustryExperiences.map((ie) => (
                 <Badge key={ie.industry}>
                   {ie.industry} - {ie.experienceLevel}
                 </Badge>
               ))}
             </div>
-            <div className="max-w-md">
-              <Popover>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="outline"
-                    role="combobox"
-                    className={cn(
-                      "w-full justify-between",
-                      !selectedIndustryExperiences.length && "text-muted-foreground"
-                    )}
-                  >
-                    {selectedIndustryExperiences.length
-                      ? `${selectedIndustryExperiences.length} selected`
-                      : t('ProfessionalSection.select')}
-                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
-                  <Command>
-                    <CommandInput placeholder={t('ProfessionalSection.search')} />
-                    <CommandEmpty>No industry found</CommandEmpty>
-                    <CommandGroup>
-                      <CommandList>
-                        {industriesMapper.map((industry) => (
-                          <CommandItem
-                            key={industry.value}
-                            value={industry.value}
-                            onSelect={() => toggleIndustryExperience(industry.value as Industry, 'BEGINNER' as ExperienceLevel)}
-                          >
-                            <Check
-                              className={cn(
-                                "mr-2 h-4 w-4",
-                                selectedIndustryExperiences.some(ie => ie.industry === industry.value) 
-                                  ? "opacity-100" 
-                                  : "opacity-0"
-                              )}
-                            />
-                            {industry.label}
-                          </CommandItem>
-                        ))}
-                      </CommandList>
-                    </CommandGroup>
-                  </Command>
-                </PopoverContent>
-              </Popover>
-            </div>
-          </div>
-          <div className="space-y-2">
-            <Label>{t('ProfessionalSection.experience')}</Label>
-            <div className="max-w-md">
-              <Popover>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="outline"
-                    role="combobox"
-                    className={cn(
-                      "w-full justify-between",
-                      !selectedIndustryExperiences.length && "text-muted-foreground"
-                    )}
-                  >
-                    {t('ProfessionalSection.select')}
-                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
-                  <Command>
-                    <CommandInput placeholder={t('ProfessionalSection.search')} />
-                    <CommandEmpty>{t('ProfessionalSection.noExperienceFound')}</CommandEmpty>
-                    <CommandGroup>
-                      <CommandList>
-                        {experienceLevelsMapper.map((level) => (
-                          <CommandItem
-                            key={level.value}
-                            value={level.value}
-                            onSelect={(value) => {
-                              if (selectedIndustryExperiences.length > 0) {
-                                setSelectedIndustryExperiences(current => 
-                                  current.map(ie => ({
-                                    ...ie,
-                                    experienceLevel: value as ExperienceLevel
-                                  }))
-                                );
-                              }
-                            }}
-                          >
-                            <Check
-                              className={cn(
-                                "mr-2 h-4 w-4",
-                                selectedIndustryExperiences.some(ie => ie.experienceLevel === level.value)
-                                  ? "opacity-100"
-                                  : "opacity-0"
-                              )}
-                            />
-                            {level.label}
-                          </CommandItem>
-                        ))}
-                      </CommandList>
-                    </CommandGroup>
-                  </Command>
-                </PopoverContent>
-              </Popover>
-            </div>
+
+            {!isAdding ? (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setIsAdding(true)}
+                className="mt-2"
+              >
+                <Plus className="mr-2 h-4 w-4" />
+                Add Industry & Experience
+              </Button>
+            ) : (
+              <div className="mt-2 flex gap-2">
+                <div className="flex-1">
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <Button
+                        variant="outline"
+                        role="combobox"
+                        className="w-full justify-between"
+                      >
+                        {newIndustry || "Select Industry"}
+                        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+                      <Command>
+                        <CommandInput placeholder="Search industry..." />
+                        <CommandList>
+                          <CommandEmpty>No industry found</CommandEmpty>
+                          <CommandGroup>
+                            {industriesMapper.map((industry) => (
+                              <CommandItem
+                                key={industry.value}
+                                value={industry.value}
+                                onSelect={() =>
+                                  setNewIndustry(industry.value as Industry)
+                                }
+                              >
+                                <Check
+                                  className={cn(
+                                    "mr-2 h-4 w-4",
+                                    newIndustry === industry.value
+                                      ? "opacity-100"
+                                      : "opacity-0",
+                                  )}
+                                />
+                                {industry.label}
+                              </CommandItem>
+                            ))}
+                          </CommandGroup>
+                        </CommandList>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
+                </div>
+
+                <div className="flex-1">
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <Button
+                        variant="outline"
+                        role="combobox"
+                        className="w-full justify-between"
+                      >
+                        {newExperience || "Select Experience"}
+                        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+                      <Command>
+                        <CommandInput placeholder="Search experience level..." />
+                        <CommandList>
+                          <CommandEmpty>No experience level found</CommandEmpty>
+                          <CommandGroup>
+                            {experienceLevelsMapper.map((level) => (
+                              <CommandItem
+                                key={level.value}
+                                value={level.value}
+                                onSelect={() =>
+                                  setNewExperience(
+                                    level.value as ExperienceLevel,
+                                  )
+                                }
+                              >
+                                <Check
+                                  className={cn(
+                                    "mr-2 h-4 w-4",
+                                    newExperience === level.value
+                                      ? "opacity-100"
+                                      : "opacity-0",
+                                  )}
+                                />
+                                {level.label}
+                              </CommandItem>
+                            ))}
+                          </CommandGroup>
+                        </CommandList>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
+                </div>
+
+                <Button
+                  onClick={addIndustryExperience}
+                  disabled={!newIndustry || !newExperience}
+                >
+                  Add
+                </Button>
+              </div>
+            )}
           </div>
         </div>
       </CardContent>
     </Card>
-  )
+  );
 }

--- a/components/profile/ProfileCard.tsx
+++ b/components/profile/ProfileCard.tsx
@@ -118,7 +118,7 @@ function ProfileCard({
                       leftContent={exp.industry}
                       rightContent={exp.experienceLevel}
                       leftColor="bg-primary"
-                      rightColor="bg-secondary"
+                      rightColor="bg-primary/80"
                     />
                   ))}
                 </div>

--- a/components/profile/ProfileCard.tsx
+++ b/components/profile/ProfileCard.tsx
@@ -10,13 +10,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
-
-// Wrapper imports
+import { ComboBadge } from "@/components/ui/combo-badge";
 
 // Schema imports
 import { PortfolioArtworkWithDetails } from "@/drizzle/schema/portfolio";
-
-// Hook imports
 
 // Utility imports
 import { getSocialMediaLinks } from "@/utils/social_media";
@@ -40,18 +37,6 @@ interface UserSkills {
   name: string;
 }
 
-async function getUserSkills(userId?: string): Promise<UserSkills[]> {
-  // TODO: Implement actual skill fetching logic
-  // This is a placeholder implementation
-  return [
-    { id: 1, name: "JavaScript" },
-    { id: 2, name: "React" },
-    { id: 3, name: "Node.js" },
-    { id: 4, name: "TypeScript" },
-    { id: 5, name: "GraphQL" },
-  ];
-}
-
 function ProfileCard({
   t,
   userData,
@@ -72,148 +57,139 @@ function ProfileCard({
   const phoneNumber = getFormattedPhoneNumber(userData);
 
   return (
-      <Card className="flex h-fit flex-col overflow-auto">
-        <CardHeader className="flex flex-col items-center">
-          <div className="mb-4 h-24 w-24 overflow-hidden rounded-lg">
-            <img
-              src={profilePictureUrl}
-              alt={`${name}'s profile`}
-              className="h-full w-full object-cover"
-            />
-          </div>
-          <CardTitle className="mb-2 flex items-center text-2xl font-bold">
-            <UserCircle className="mr-2 h-6 w-6" />
-            {name}
-          </CardTitle>
-          {userName && (
-            <p className="mb-2 flex items-center text-sm text-gray-500">
-              @{userName}
-            </p>
-          )}
-          <div className="mb-2 flex items-center gap-2">
-            <Badge variant="success" className="flex items-center">
-              <CheckCircle className="mr-1 h-3 w-3" />
-              {t("openToCollab")}
-            </Badge>
-            <Badge variant="secondary" className="flex items-center">
-              <Image className="mr-1 h-3 w-3" />
-              {portfolioArtworks.length} {t("artworks")}
-            </Badge>
-          </div>
-          <p className="mb-4 flex items-center text-sm text-gray-500">
-            <MapPin className="mr-1 h-4 w-4" />
-            {userData.location}
+    <Card className="flex h-fit flex-col overflow-auto">
+      <CardHeader className="flex flex-col items-center">
+        <div className="mb-4 h-24 w-24 overflow-hidden rounded-lg">
+          <img
+            src={profilePictureUrl}
+            alt={`${name}'s profile`}
+            className="h-full w-full object-cover"
+          />
+        </div>
+        <CardTitle className="mb-2 flex items-center text-2xl font-bold">
+          <UserCircle className="mr-2 h-6 w-6" />
+          {name}
+        </CardTitle>
+        {userName && (
+          <p className="mb-2 flex items-center text-sm text-gray-500">
+            @{userName}
           </p>
-          <div className="flex space-x-2">
-            <Button variant="outline" size="sm" asChild>
-              <a href="/profile/edit">
-                <Pencil className="mr-1 h-4 w-4" />
-                {t("edit")}
-              </a>
-            </Button>
-          </div>
-          {userData.about && (
-            <section data-section="about" className="pt-4">
-              <h3 className="mb-2 text-lg font-semibold">{t("about")}</h3>
-              <p>{userData.about}</p>
-            </section>
-          )}
-        </CardHeader>
-        <Separator className="my-4" />
-        <CardContent className="mt-4">
-          <div className="space-y-6">
-            {userData.industries && userData.industries.length > 0 && (
+        )}
+        <div className="mb-2 flex items-center gap-2">
+          <Badge variant="success" className="flex items-center">
+            <CheckCircle className="mr-1 h-3 w-3" />
+            {t("openToCollab")}
+          </Badge>
+          <Badge variant="secondary" className="flex items-center">
+            <Image className="mr-1 h-3 w-3" />
+            {portfolioArtworks.length} {t("artworks")}
+          </Badge>
+        </div>
+        <p className="mb-4 flex items-center text-sm text-gray-500">
+          <MapPin className="mr-1 h-4 w-4" />
+          {userData.location}
+        </p>
+        <div className="flex space-x-2">
+          <Button variant="outline" size="sm" asChild>
+            <a href="/profile/edit">
+              <Pencil className="mr-1 h-4 w-4" />
+              {t("edit")}
+            </a>
+          </Button>
+        </div>
+        {userData.about && (
+          <section data-section="about" className="pt-4">
+            <h3 className="mb-2 text-lg font-semibold">{t("about")}</h3>
+            <p>{userData.about}</p>
+          </section>
+        )}
+      </CardHeader>
+      <Separator className="my-4" />
+      <CardContent className="mt-4">
+        <div className="space-y-6">
+          {userData.industryExperiences &&
+            userData.industryExperiences.length > 0 && (
               <section data-section="industry">
                 <h3 className="mb-2 text-lg font-semibold">{t("industry")}</h3>
                 <div className="flex flex-wrap gap-2">
-                  {userData.industries.map((industry) => (
-                    <Badge key={industry} variant="default" className="text-xs">
-                      {industry}
-                    </Badge>
+                  {userData.industryExperiences.map((exp) => (
+                    <ComboBadge
+                      key={`${exp.industry}-${exp.experienceLevel}`}
+                      leftContent={exp.industry}
+                      rightContent={exp.experienceLevel}
+                      leftColor="bg-primary"
+                      rightColor="bg-secondary"
+                    />
                   ))}
                 </div>
               </section>
             )}
-            {userData.experience && (
-              <section data-section="experience">
-                <h3 className="mb-2 text-lg font-semibold">
-                  {t("experience")}
-                </h3>
-                <p>{userData.experience}</p>
-              </section>
-            )}
-            {userSkills && userSkills.length > 0 && (
-              <section data-section="skills">
-                <h3 className="mb-2 text-lg font-semibold">{t("skills")}</h3>
-                <div className="flex flex-wrap gap-2">
-                  {userSkills.map((skill) => (
-                    <Badge
-                      key={skill.id}
-                      variant="secondary"
-                      className="text-xs"
-                    >
-                      {skill.name}
-                    </Badge>
-                  ))}
-                </div>
-              </section>
-            )}
-            <Separator className="my-4" />
-            <section data-section="contact">
-              <h3 className="mb-2 text-lg font-semibold">{t("contact")}</h3>
-              <ul className="space-y-2">
-                {userData.email && (
-                  <li className="flex items-center">
-                    <Mail className="mr-2 h-4 w-4" />
-                    <a
-                      href={`mailto:${userData.email}`}
-                      className="text-primary hover:underline"
-                    >
-                      {userData.email}
-                    </a>
-                  </li>
-                )}
-                {phoneNumber && (
-                  <li className="flex items-center">
-                    <Phone className="mr-2 h-4 w-4" />
-                    <a
-                      href={`tel:${phoneNumber}`}
-                      className="text-primary hover:underline"
-                    >
-                      {phoneNumber}
-                    </a>
-                  </li>
-                )}
-              </ul>
+          {userSkills && userSkills.length > 0 && (
+            <section data-section="skills">
+              <h3 className="mb-2 text-lg font-semibold">{t("skills")}</h3>
+              <div className="flex flex-wrap gap-2">
+                {userSkills.map((skill) => (
+                  <Badge key={skill.id} variant="secondary" className="text-xs">
+                    {skill.name}
+                  </Badge>
+                ))}
+              </div>
             </section>
-            <Separator className="my-4" />
-            {userData && (
-              <section data-section="social-links">
-                <h3 className="mb-2 text-lg font-semibold">
-                  {t("socialLinks")}
-                </h3>
-                <div className="flex space-x-4">
-                  {getSocialMediaLinks(userData).map(
-                    (link, index) =>
-                      link &&
-                      link.url && (
-                        <a
-                          key={index}
-                          href={link.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-primary hover:text-primary-600"
-                        >
-                          <link.icon className="h-6 w-6" />
-                        </a>
-                      ),
-                  )}
-                </div>
-              </section>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+          )}
+          <Separator className="my-4" />
+          <section data-section="contact">
+            <h3 className="mb-2 text-lg font-semibold">{t("contact")}</h3>
+            <ul className="space-y-2">
+              {userData.email && (
+                <li className="flex items-center">
+                  <Mail className="mr-2 h-4 w-4" />
+                  <a
+                    href={`mailto:${userData.email}`}
+                    className="text-primary hover:underline"
+                  >
+                    {userData.email}
+                  </a>
+                </li>
+              )}
+              {phoneNumber && (
+                <li className="flex items-center">
+                  <Phone className="mr-2 h-4 w-4" />
+                  <a
+                    href={`tel:${phoneNumber}`}
+                    className="text-primary hover:underline"
+                  >
+                    {phoneNumber}
+                  </a>
+                </li>
+              )}
+            </ul>
+          </section>
+          <Separator className="my-4" />
+          {userData && (
+            <section data-section="social-links">
+              <h3 className="mb-2 text-lg font-semibold">{t("socialLinks")}</h3>
+              <div className="flex space-x-4">
+                {getSocialMediaLinks(userData).map(
+                  (link, index) =>
+                    link &&
+                    link.url && (
+                      <a
+                        key={index}
+                        href={link.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary hover:text-primary-600"
+                      >
+                        <link.icon className="h-6 w-6" />
+                      </a>
+                    ),
+                )}
+              </div>
+            </section>
+          )}
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/components/ui/combo-badge.tsx
+++ b/components/ui/combo-badge.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+interface ComboBadgeProps {
+  leftContent: React.ReactNode
+  rightContent: React.ReactNode
+  leftColor?: string
+  rightColor?: string
+}
+
+export function ComboBadge({
+  leftContent,
+  rightContent,
+  leftColor = 'bg-primary',
+  rightColor = 'bg-primary'
+}: ComboBadgeProps) {
+  return (
+    <div className="inline-flex rounded-full overflow-hidden text-xs font-medium transition-all duration-300 hover:shadow-md">
+      <div className={`${leftColor} text-white px-2 py-1 transition-opacity duration-300 hover:opacity-90`}>{leftContent}</div>
+      <div className={`${rightColor} text-white px-2 py-1 transition-opacity duration-300 hover:opacity-90`}>{rightContent}</div>
+    </div>
+  )
+}

--- a/components/user/ProfessionalInfoStep.tsx
+++ b/components/user/ProfessionalInfoStep.tsx
@@ -20,14 +20,14 @@ import { cn } from "@/lib/utils"
 import { Check, ChevronsUpDown } from "lucide-react"
 import React from 'react'
 import { UseFormReturn } from 'react-hook-form'
-import { useTranslation, Trans } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { industriesMapper, experienceLevelsMapper, IndustryType, ExperienceType } from "@/drizzle/schema/user";
 
 interface ProfessionalInfoStepProps {
   form: UseFormReturn<ProfessionalInfoData>
 }
 
-const IndustrySelect = ({ form }: ProfessionalInfoStepProps) => {
+const IndustryExperienceSelect = ({ form }: ProfessionalInfoStepProps) => {
   // State
   const [open, setOpen] = React.useState(false)
   // I18n
@@ -36,7 +36,7 @@ const IndustrySelect = ({ form }: ProfessionalInfoStepProps) => {
   return (
     <FormField
       control={form.control}
-      name="industries"
+      name="industryExperiences"
       render={({ field }) => (
         <FormItem className="flex flex-col">
           <FormLabel>{t("label")}</FormLabel>
@@ -71,16 +71,20 @@ const IndustrySelect = ({ form }: ProfessionalInfoStepProps) => {
                         value={industry.value}
                         onSelect={(currentValue) => {
                           const newValue = field.value || [];
-                          const updatedValue = newValue.includes(currentValue as IndustryType)
-                            ? newValue.filter((val) => val !== currentValue)
-                            : [...newValue, currentValue as IndustryType];
-                          form.setValue("industries", updatedValue, { shouldValidate: true });
+                          const exists = newValue.find(ie => ie.industry === currentValue);
+                          const updatedValue = exists
+                            ? newValue.filter(ie => ie.industry !== currentValue)
+                            : [...newValue, { 
+                                industry: currentValue as IndustryType,
+                                experienceLevel: 'Entry' as ExperienceType
+                              }];
+                          form.setValue("industryExperiences", updatedValue, { shouldValidate: true });
                         }}
                       >
                         <Check
                           className={cn(
                             "mr-2 h-4 w-4",
-                            field.value?.includes(industry.value) ? "opacity-100" : "opacity-0"
+                            field.value?.some(ie => ie.industry === industry.value) ? "opacity-100" : "opacity-0"
                           )}
                         />
                         {industry.label}
@@ -91,75 +95,7 @@ const IndustrySelect = ({ form }: ProfessionalInfoStepProps) => {
               </Command>
             </PopoverContent>
           </Popover>
-          <FormMessage>{form.formState.errors.industries?.message}</FormMessage>
-        </FormItem>
-      )}
-    />
-  )
-}
-
-const ExperienceSelect = ({ form }: ProfessionalInfoStepProps) => {
-  // State
-  const [open, setOpen] = React.useState(false)
-  // I18n
-  const { t } = useTranslation(["ProfessionalInfoStep"], { keyPrefix: "ExperienceSelect" });
-
-  return (
-    <FormField
-      control={form.control}
-      name="experience"
-      render={({ field }) => (
-        <FormItem className="flex flex-col">
-          <FormLabel>{t("label")}</FormLabel>
-          <Popover open={open} onOpenChange={setOpen}>
-            <PopoverTrigger asChild>
-              <FormControl>
-                <Button
-                  variant="outline"
-                  role="combobox"
-                  aria-expanded={open}
-                  className={cn(
-                    "w-full justify-between",
-                    !field.value && "text-muted-foreground"
-                  )}
-                >
-                  {field.value
-                    ? experienceLevelsMapper.find((level) => level.value === field.value)?.label
-                    : t("select")}
-                  <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                </Button>
-              </FormControl>
-            </PopoverTrigger>
-            <PopoverContent className="w-[200px] p-0">
-              <Command>
-                <CommandInput placeholder={t("search")} />
-                <CommandEmpty>{t("noExperienceFound")}</CommandEmpty>
-                <CommandGroup>
-                  <CommandList>
-                    {experienceLevelsMapper.map((level) => (
-                      <CommandItem
-                        key={level.value}
-                        value={level.value}
-                        onSelect={(value) => {
-                          form.setValue("experience", value as typeof level.value, { shouldValidate: true });
-                          setOpen(false);
-                        }}
-                      >
-                        <Check
-                          className={cn(
-                            "mr-2 h-4 w-4",
-                            field.value === level.value ? "opacity-100" : "opacity-0"
-                          )}
-                        />
-                        {level.label}
-                      </CommandItem>
-                    ))}
-                  </CommandList>
-                </CommandGroup>
-              </Command>
-            </PopoverContent>
-          </Popover>
-          <FormMessage>{form.formState.errors.experience?.message}</FormMessage>
+          <FormMessage>{form.formState.errors.industryExperiences?.message}</FormMessage>
         </FormItem>
       )}
     />
@@ -167,13 +103,9 @@ const ExperienceSelect = ({ form }: ProfessionalInfoStepProps) => {
 }
 
 export function ProfessionalInfoStep({ form }: ProfessionalInfoStepProps) {
-  // I18n
-  const { t } = useTranslation();
-
   return (
     <div className="space-y-4">
-      <IndustrySelect form={form} />
-      <ExperienceSelect form={form} />
+      <IndustryExperienceSelect form={form} />
     </div>
   )
 }

--- a/services/user-service.ts
+++ b/services/user-service.ts
@@ -10,6 +10,7 @@ import {
   professionalInfoSchema,
   type ProfessionalInfoData,
 } from "@/app/form-schemas/professional-info";
+import { type UserIndustryExperience } from "@/drizzle/schema/user";
 
 export class UserService {
   static async updateUserInfo(
@@ -28,8 +29,7 @@ export class UserService {
       phoneCountryAlpha3,
       instagramHandle,
       facebookHandle,
-      industries,
-      experience,
+      industryExperiences,
       about,
     } = data;
 
@@ -45,33 +45,7 @@ export class UserService {
         phoneCountryAlpha3: phoneCountryAlpha3 || "VNM",
       },
       {
-        industries:
-          industries ||
-          ([] as (
-            | "Advertising"
-            | "Architecture"
-            | "Arts and Crafts"
-            | "Design"
-            | "Fashion"
-            | "Film, Video, and Photography"
-            | "Music"
-            | "Performing Arts"
-            | "Publishing"
-            | "Software and Interactive"
-            | "Television and Radio"
-            | "Visual Arts"
-            | "Other"
-          )[]),
-        experience:
-          experience ||
-          (null as
-            | "Entry"
-            | "Junior"
-            | "Mid-level"
-            | "Senior"
-            | "Manager"
-            | "C-level"
-            | null),
+        industryExperiences: (industryExperiences || []) as UserIndustryExperience[],
       },
       {
         instagramHandle,

--- a/supabase/migrations/20241123044655_connect_industry_and_seniority.sql
+++ b/supabase/migrations/20241123044655_connect_industry_and_seniority.sql
@@ -1,0 +1,59 @@
+-- Migration: connect_industry_and_seniority
+-- Created at: 2024-11-23 04:46:55
+-- Description: Creates a new table to track user experience levels per industry
+
+BEGIN;
+
+-- First, create the new table to track user experience per industry
+CREATE TABLE user_industry_experience (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES user_infos(id) ON DELETE CASCADE,
+    industry industry NOT NULL,
+    experience_level experience_level NOT NULL,
+    UNIQUE(user_id, industry)
+);
+
+COMMENT ON TABLE user_industry_experience IS 'Tracks user experience levels per industry';
+COMMENT ON COLUMN user_industry_experience.user_id IS 'The ID of the user';
+COMMENT ON COLUMN user_industry_experience.industry IS 'The industry the user has experience in';
+COMMENT ON COLUMN user_industry_experience.experience_level IS 'The experience level of the user in the industry';
+
+-- Create index for faster lookups
+CREATE INDEX idx_user_industry_experience_user_id ON user_industry_experience(user_id);
+
+-- Then, copy existing industry and experience data to the new table,
+-- assuming that the experience level is the same for all industries
+-- knowing that industries is an array; and experience is a single value (use unnest)
+INSERT INTO user_industry_experience (user_id, industry, experience_level)
+SELECT id, industry, experience FROM user_infos, unnest(industries) AS industry;
+
+
+-- Finally, remove existing industry and experience columns from user_infos
+ALTER TABLE user_infos 
+DROP COLUMN IF EXISTS industries,
+DROP COLUMN IF EXISTS experience;
+
+-- Verification
+DO $$
+BEGIN
+    -- Check if the user_industry_experience table exists
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_name = 'user_industry_experience'
+    ) THEN
+        RAISE EXCEPTION 'Table "user_industry_experience" was not created';
+    END IF;
+
+    -- Check if the required columns exist
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'user_industry_experience'
+          AND column_name IN ('id', 'user_id', 'industry', 'experience_level', 'years_of_experience')
+    ) THEN
+        RAISE EXCEPTION 'Required columns are missing in user_industry_experience table';
+    END IF;
+END $$;
+
+COMMIT;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -176,8 +176,6 @@ INSERT INTO user_infos (
     location,
     occupation,
     about,
-    industries,
-    experience,
     profile_picture,
     instagram_handle,
     facebook_handle
@@ -193,8 +191,6 @@ INSERT INTO user_infos (
     'New York',
     'System Administrator',
     'Experienced creative technologist with a passion for integrating cutting-edge technology into artistic projects and interactive experiences.',
-    ARRAY['Software and Interactive', 'Other']::industry[],
-    'Senior'::experience_level,
     '7c37e6b3-5e62-4f76-b67c-0d5a42b92a2d/lukewarm._Abstract_expressionism_emerald-powered_river-dwelling_9c99d61d-cd4b-4534-8a4e-ee60d1862ed2.png',
     'admin_insta',
     'admin_fb'
@@ -210,8 +206,6 @@ INSERT INTO user_infos (
     'San Francisco',
     'Software Developer',
     'Passionate software developer with a focus on creative technologies, eager to innovate at the intersection of art and code.',
-    ARRAY['Software and Interactive']::industry[],
-    'Entry'::experience_level,
     NULL,
     'user_insta',
     'user_fb'
@@ -227,12 +221,19 @@ INSERT INTO user_infos (
     'Lam Dong, Vietnam',
     'Software Developer',
     'Passionate software developer with a focus on creative technologies, eager to innovate at the intersection of art and code.',
-    ARRAY['Software and Interactive']::industry[],
-    'Senior'::experience_level,
     '314f834c-3ff2-4382-bc92-d37cbe2286a8/lukewarm._a_river_water-elemental_lion_drawing_power_from_emera_cd875218-db8a-4ab4-afdd-a00a1a6deb49.png',
     'vl307',
     'vl307'
 );
+
+-- Seed data for user_industry_experience table
+INSERT INTO user_industry_experience (user_id, industry, experience_level) VALUES
+('7c37e6b3-5e62-4f76-b67c-0d5a42b92a2d', 'Software and Interactive', 'Senior'),
+('7c37e6b3-5e62-4f76-b67c-0d5a42b92a2d', 'Other', 'Senior'),
+('13f60da9-8dd4-42f9-8a57-c0569a158857', 'Software and Interactive', 'Entry'),
+('13f60da9-8dd4-42f9-8a57-c0569a158857', 'Film, Video, and Photography', 'Junior'),
+('314f834c-3ff2-4382-bc92-d37cbe2286a8', 'Software and Interactive', 'Senior'),
+('314f834c-3ff2-4382-bc92-d37cbe2286a8', 'Advertising', 'Mid-level');
 
 -- Seed data for events table
 INSERT INTO events (id, created_at, name, slug, created_by)


### PR DESCRIPTION
## Description

Restructures how we handle industry and experience data across the application, introducing a unified industry-experience model using combo badges for consistent UI representation.

## Key Changes

1. Introduced new `ComboBadge` component for consistent industry-experience display
2. Refactored professional info data structure to combine industry and experience levels
3. Updated form handling in ProfessionalSection and ProfileCard components
4. Standardized styling using primary color with opacity variants
5. Migrated existing industry/experience separate fields to combined model

## Breaking Changes

- Changed data structure from separate `industries` and `experience` fields to combined `industryExperiences` array
- Modified form schemas and validation logic for professional information
- Updated API response structure for user profile data

## Related Issues

- Closes WEB-214

## Testing Instructions

1. Navigate to profile editing page
2. Verify industry-experience combo selection works:
   - Add new industry with experience level
   - Remove existing combinations
   - Edit existing combinations
3. Check display consistency across:
   - Profile card
   - Contact cards
   - Professional section
4. Verify form validation and submission
5. Test responsive design of combo badges

## Additional Notes

- This change improves UI consistency and data organization
- The new combo badge component uses primary color with 80% opacity variant for visual hierarchy
- Migration scripts may be needed for existing user data
- Component changes affect multiple views but maintain backwards compatibility in the API layer