### PR TITLE
feat(profile): add delete functionality to industry experience badges

### DIFF
--- a/components/profile/ProfessionalSection.tsx
+++ b/components/profile/ProfessionalSection.tsx
@@ -144,8 +144,12 @@ export function ProfessionalSection({
   lang = "en",
 }: ProfessionalSectionProps) {
   const { t } = useTranslation(lang, "ProfilePage");
-  const [selectedIndustryExperiences, setSelectedIndustryExperiences] =
-    useState(userData.industryExperiences || []);
+  const [selectedIndustryExperiences, setSelectedIndustryExperiences] = useState(
+    (userData.industryExperiences || []).map(ie => ({
+      ...ie,
+      id: ie.id || crypto.randomUUID()
+    }))
+  );
   const [isAdding, setIsAdding] = useState(false);
   const [newIndustry, setNewIndustry] = useState<Industry | null>(null);
   const [newExperience, setNewExperience] = useState<ExperienceLevel | null>(
@@ -172,10 +176,13 @@ export function ProfessionalSection({
 
   const addIndustryExperience = () => {
     if (newIndustry && newExperience) {
+      const newId = crypto.randomUUID();
+      console.log('Adding new item with ID:', newId);
+      
       setSelectedIndustryExperiences((current) => [
         ...current,
         {
-          id: crypto.randomUUID(),
+          id: newId,
           userId: userData.id,
           industry: newIndustry,
           experienceLevel: newExperience,
@@ -185,6 +192,19 @@ export function ProfessionalSection({
       setNewIndustry(null);
       setNewExperience(null);
     }
+  };
+
+  const deleteIndustryExperience = (idToDelete: string) => {
+    console.log('Deleting item with ID:', idToDelete);
+    
+    setSelectedIndustryExperiences((current) => {
+      console.log('Current items:', current);
+      
+      return current.filter((ie) => {
+        console.log('Comparing:', ie.id, idToDelete);
+        return ie.id !== idToDelete;
+      });
+    });
   };
 
   return (
@@ -199,11 +219,16 @@ export function ProfessionalSection({
             <div className="mt-2 flex flex-wrap gap-2">
               {selectedIndustryExperiences.map((ie) => (
                 <ComboBadge
-                  key={ie.industry}
+                  key={ie.id}
+                  data-id={ie.id}
                   leftContent={ie.industry}
                   rightContent={ie.experienceLevel}
                   leftColor="bg-primary"
                   rightColor="bg-primary/80"
+                  onDelete={() => {
+                    console.log('Deleting badge with ID:', ie.id);
+                    deleteIndustryExperience(ie.id);
+                  }}
                 />
               ))}
             </div>

--- a/components/ui/combo-badge.tsx
+++ b/components/ui/combo-badge.tsx
@@ -1,22 +1,39 @@
 import React from 'react'
+import { X } from 'lucide-react'
 
 interface ComboBadgeProps {
   leftContent: React.ReactNode
   rightContent: React.ReactNode
   leftColor?: string
   rightColor?: string
+  onDelete?: () => void
 }
 
 export function ComboBadge({
   leftContent,
   rightContent,
   leftColor = 'bg-primary',
-  rightColor = 'bg-primary'
+  rightColor = 'bg-primary',
+  onDelete
 }: ComboBadgeProps) {
   return (
-    <div className="inline-flex rounded-full overflow-hidden text-xs font-medium transition-all duration-300 hover:shadow-md">
+    <div className="inline-flex rounded-full overflow-hidden text-xs font-medium transition-all duration-300 hover:shadow-md group">
       <div className={`${leftColor} text-white px-2 py-1 transition-opacity duration-300 hover:opacity-90`}>{leftContent}</div>
-      <div className={`${rightColor} text-white px-2 py-1 transition-opacity duration-300 hover:opacity-90`}>{rightContent}</div>
+      <div className={`${rightColor} text-white px-2 py-1 transition-opacity duration-300 hover:opacity-90 flex items-center gap-1`}>
+        {rightContent}
+        {onDelete && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete();
+            }}
+            className="ml-1 p-0.5 rounded-full hover:bg-white/20 transition-colors"
+            aria-label="Delete"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Description

Add delete functionality to industry experience badges in the profile section, allowing users to remove their industry experiences directly from the UI.

## Key Changes

1. Enhanced ComboBadge component with delete button functionality
2. Implemented deleteIndustryExperience handler in ProfessionalSection
3. Added proper ID generation and management for industry experiences
4. Added debug logging for delete operations
5. Updated badge key props to use unique IDs for proper React reconciliation

## Breaking Changes

- ComboBadge component now requires unique IDs for proper functioning
- Industry experience objects must include an `id` field

## Related Issues

- Closes WEB-239

## Testing Instructions

1. Navigate to the Professional Section of a user profile
2. Verify that industry experience badges now show a delete (X) button on hover
3. Click the delete button on a badge and verify:
   - The badge is removed from the UI
   - Console logs show the correct ID being deleted
   - The experience is removed from the selectedIndustryExperiences state
4. Add a new industry experience and verify it gets a unique ID
5. Test multiple deletions to ensure state management remains consistent

## Additional Notes

- Added console logging for debugging purposes - these could be removed before production
- The crypto.randomUUID() is used for generating unique IDs - ensure browser compatibility
- Consider adding a confirmation dialog before deletion in future iterations