### PR TITLE
feat(ui): redesign screens, add contacts page, make phone optional

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,34 +1,63 @@
 // File: app/(auth)/login/page.tsx
 "use client";
 
-import { MagicSignIn } from '@/components/auth/MagicSignIn';
-import { BackgroundDiv } from '@/components/wrappers/BackgroundDiv';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-import { Suspense } from 'react';
-import { Loading } from '@/components/Loading';
+// UI components
+import { MagicSignIn } from "@/components/auth/MagicSignIn";
+import { BackgroundDiv } from "@/components/wrappers/BackgroundDiv";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Loading } from "@/components/Loading";
+import { HeroTitle } from "@/components/ui/typography";
 
-function LoginContent() {
-  return (
-    <Card className="w-[400px] overflow-hidden relative z-10">
-      <CardHeader className="border-b aspect-video bg-accent-foreground text-accent-foreground"
-        style={{
-          backgroundImage: 'url(/banner.jpg)',
-          backgroundSize: 'cover',
-        }}
-      />
-      <CardContent className='p-6 flex flex-col gap-2'>
-        <MagicSignIn purpose="login" />
-      </CardContent>
-    </Card>
-  );
-}
+// React imports
+import { Suspense } from "react";
+
+// Utility
+import { cn } from "@/lib/utils";
 
 export default function LoginPage() {
   return (
-    <BackgroundDiv>
-      <Suspense fallback={<Loading />}>
-        <LoginContent />
-      </Suspense>
+    <BackgroundDiv
+      shouldCenter={false}
+      className={cn(
+        "flex flex-col md:flex-row h-screen w-full overflow-hidden"
+      )}
+    >
+      {/* Hero / Illustration section */}
+      <div
+        className={cn(
+          "order-2 md:order-1 flex-1 hidden md:block",
+          "bg-[url('/banner.jpg')] bg-cover bg-center"
+        )}
+      />
+
+      {/* Login form section */}
+      <div
+        className={cn(
+          "order-1 md:order-2 flex-1",
+          "flex items-center justify-center"
+        )}
+      >
+        <Suspense fallback={<Loading />}>
+          <Card className="w-[90%] max-w-[420px] overflow-hidden border-4 border-black shadow-[4px_4px_0_0_#000]">
+            {/* Mobile banner */}
+            <CardHeader
+              className="aspect-video md:hidden bg-[url('/banner.jpg')] bg-cover bg-center relative"
+            />
+            <CardContent className="p-6 flex flex-col gap-6">
+              {/* Brand heading */}
+              <HeroTitle
+                size="small"
+                bordered="black"
+                variant="accent"
+                className="text-black text-center"
+              >
+                LOG&nbsp;IN
+              </HeroTitle>
+              <MagicSignIn purpose="login" />
+            </CardContent>
+          </Card>
+        </Suspense>
+      </div>
     </BackgroundDiv>
   );
 }

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect, use } from 'react';
+import React, { useState, useEffect, use, Suspense } from 'react';
 import { useForm, FormProvider, UseFormReturn } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -17,6 +17,9 @@ import { contactInfoSchema, ContactInfoData } from '@/app/form-schemas/contact-i
 import { professionalInfoSchema, ProfessionalInfoData } from '@/app/form-schemas/professional-info'
 import { BackgroundDiv } from '@/components/wrappers/BackgroundDiv'
 import { IndustryType, ExperienceType } from '@/drizzle/schema/user'
+import { Loading } from '@/components/Loading';
+import { HeroTitle } from '@/components/ui/typography';
+import { cn } from '@/lib/utils';
 
 const signupSchema = z.object({
   ...contactInfoSchema.shape,
@@ -147,44 +150,90 @@ export default function SignupPage(
   }
 
   return (
-    <BackgroundDiv>
-      <Card className="w-[400px] mx-auto mt-10">
-        <CardHeader
-          className="border-b aspect-video bg-accent-foreground text-accent-foreground"
-          style={{
-            backgroundImage: 'url(/signup-background.png), url(/banner.jpg)',
-            backgroundSize: 'cover',
-          }}
-        />
-        <CardContent className="p-6 flex flex-col gap-2">
-          <div
-            className="flex flex-col space-y-2 p-4 bg-primary bg-opacity-10 rounded-md"
-          >
-            <h2 className="text-2xl font-semibold text-primary">{currentStep.title}</h2>
-            <p>{currentStep.description}</p>
-            <Progress value={progress} className="w-full" />
-          </div>
-          <FormProvider {...currentStep.form as unknown as FormContextType}>
-            <form onSubmit={currentStep.form.handleSubmit(step === steps.length - 1 ? handleSubmit : handleNextStep)}>
-              {currentStep.component}
-              <div className="flex justify-between mt-4">
-                {step > 0 && (
-                  <Button type="button" onClick={() => setStep((prev) => prev - 1)} disabled={isSubmitting}>
-                    {t('Button.back')}
-                  </Button>
-                )}
-                <Button type="submit" disabled={isSubmitting}>
-                  {isSubmitting
-                    ? t('Button.submitting')
-                    : step === steps.length - 1
-                      ? t('Button.submit')
-                      : t('Button.next')}
-                </Button>
+    <BackgroundDiv
+      shouldCenter={false}
+      className={cn(
+        'flex flex-col md:flex-row h-screen w-full overflow-hidden'
+      )}
+    >
+      {/* Hero / Illustration section */}
+      <div
+        className={cn(
+          'order-2 md:order-1 flex-1 hidden md:block',
+          "bg-[url('/banner.jpg')] bg-cover bg-center"
+        )}
+      />
+
+      {/* Signup form section */}
+      <div
+        className={cn(
+          'order-1 md:order-2 flex-1',
+          'flex items-center justify-center'
+        )}
+      >
+        <Suspense fallback={<Loading />}>
+          <Card className="w-[90%] max-w-[420px] overflow-hidden border-4 border-black shadow-[4px_4px_0_0_#000]">
+            {/* Mobile banner */}
+            <CardHeader
+              className="aspect-video md:hidden bg-[url('/banner.jpg')] bg-cover bg-center relative"
+            />
+            <CardContent className="p-6 flex flex-col gap-6">
+              {/* Brand heading */}
+              <HeroTitle
+                size="small"
+                bordered="black"
+                variant="accent"
+                className="text-black text-center"
+              >
+                SIGN&nbsp;UP
+              </HeroTitle>
+
+              {/* Step information */}
+              <div className="flex flex-col gap-2 bg-sunglow/10 p-4 mb-2 rounded-md border border-sunglow/40">
+                <h2 className="text-2xl font-semibold text-black">{currentStep.title}</h2>
+                <p>{currentStep.description}</p>
+                <Progress
+                  value={progress}
+                  className="w-full bg-sunglow/20"
+                  indicatorClassName="bg-sunglow"
+                />
               </div>
-            </form>
-          </FormProvider>
-        </CardContent>
-      </Card>
+
+              {/* Form */}
+              <FormProvider {...(currentStep.form as unknown as FormContextType)}>
+                <form onSubmit={currentStep.form.handleSubmit(step === steps.length - 1 ? handleSubmit : handleNextStep)}>
+                  {currentStep.component}
+                  <div className="flex justify-between mt-4">
+                    {step > 0 && (
+                      <Button
+                        variant="ghost"
+                        type="button"
+                        onClick={() => setStep((prev) => prev - 1)}
+                        disabled={isSubmitting}
+                        className="bg-sunglow text-black hover:bg-yellow-400 focus-visible:ring-yellow-500"
+                      >
+                        {t('Button.back')}
+                      </Button>
+                    )}
+                    <Button
+                      variant="ghost"
+                      type="submit"
+                      disabled={isSubmitting}
+                      className="bg-sunglow text-black hover:bg-yellow-400 focus-visible:ring-yellow-500"
+                    >
+                      {isSubmitting
+                        ? t('Button.submitting')
+                        : step === steps.length - 1
+                          ? t('Button.submit')
+                          : t('Button.next')}
+                    </Button>
+                  </div>
+                </form>
+              </FormProvider>
+            </CardContent>
+          </Card>
+        </Suspense>
+      </div>
     </BackgroundDiv>
   )
 }

--- a/app/(protected)/portfolio/[artworkId]/PortfolioEditForm.tsx
+++ b/app/(protected)/portfolio/[artworkId]/PortfolioEditForm.tsx
@@ -185,7 +185,7 @@ export default function PortfolioEditForm({
   return (
     <FormProvider {...form}>
       <div className="flex flex-row space-x-8">
-        <Card className="w-full" style={{ flex: 7 }}>
+        <Card className="w-full rounded-none" style={{ flex: 7 }}>
           <CardHeader>
             <CardTitle>{isNew ? t("newProject") : t("editProject")}</CardTitle>
           </CardHeader>
@@ -269,7 +269,7 @@ export default function PortfolioEditForm({
 
         <div className="flex w-full flex-col" style={{ flex: 3 }}>
           <div className="sticky top-[100px]">
-            <Card className="w-full">
+            <Card className="w-full rounded-none">
               <CardHeader>
                 <CardTitle>{t("creditInfo")}</CardTitle>
               </CardHeader>
@@ -284,7 +284,7 @@ export default function PortfolioEditForm({
           <div className="grow"></div>{" "}
           {/* This div will take up the remaining space */}
           <div className="sticky bottom-0">
-            <Card className="w-full">
+            <Card className="w-full rounded-none">
               <CardHeader>
                 <CardTitle>{t("dataUsage")}</CardTitle>
               </CardHeader>
@@ -298,7 +298,7 @@ export default function PortfolioEditForm({
             <div className="mt-4 flex flex-col gap-4">
               <Button
                 type="submit"
-                className="w-full"
+                className="w-full rounded-none border"
                 onClick={form.handleSubmit(handleSubmit)}
               >
                 {isNew ? t("create") : t("save")}
@@ -306,7 +306,7 @@ export default function PortfolioEditForm({
               <Button
                 type="button"
                 variant="outline"
-                className="w-full"
+                className="w-full rounded-none"
                 onClick={() => router.push("/profile")}
               >
                 {t("cancel")}

--- a/app/(protected)/portfolio/new/PortfolioCreateForm.tsx
+++ b/app/(protected)/portfolio/new/PortfolioCreateForm.tsx
@@ -96,9 +96,9 @@ export function PortfolioProjectCard({ project }: PortfolioProjectCardProps) {
           </div>
 
           <div className="container flex flex-col lg:gap-1">
-            <Button className="rounded-full">Save</Button>
-            <Button className="rounded-full">Save</Button>
-            <Button className="rounded-full">Save</Button>
+            <Button className="rounded-none border">Save</Button>
+            <Button className="rounded-none border">Save</Button>
+            <Button className="rounded-none border">Save</Button>
           </div>
         </CardFooter>
       </ThumbnailProvider>

--- a/app/(protected)/portfolio/new/add_coowner.component.tsx
+++ b/app/(protected)/portfolio/new/add_coowner.component.tsx
@@ -46,7 +46,7 @@ export default function AddCoOwner({ artworkCreditForm }: AddCoOwnerProps) {
   };
   return (
     <div className="min-h-[200px] w-full">
-      <h3 className="text-sm font-semibold uppercase">Add Co-onwer</h3>
+      <h3 className="text-sm font-semibold uppercase">Add Co-owner</h3>
       <div className="mb-4 flex w-full flex-col gap-2">
         {(artworkCreditForm.getValues().coartists || []).map(
           (coartist, index) => (
@@ -124,7 +124,7 @@ export function AddCoOwnerDialog(props: AddCoOwnerDialogProps) {
   return (
     <Dialog open={props.isOpen} onOpenChange={props.setIsOpenDialog}>
       <DialogTrigger asChild>
-        <Button variant="secondary" className="w-full rounded-full">
+        <Button variant="secondary" className="w-full rounded-none border">
           <Plus className="mr-2 h-4 w-4" />
           {t("add")}
         </Button>
@@ -194,7 +194,7 @@ export function AddCoOwnerDialog(props: AddCoOwnerDialogProps) {
           <div className="justify-space-between flex">
             <Button
               type="button"
-              className="w-full rounded-full"
+              className="w-full rounded-none border"
               onClick={() =>
                 props.addCoartist(
                   newCoartist.userId,
@@ -209,7 +209,7 @@ export function AddCoOwnerDialog(props: AddCoOwnerDialogProps) {
             </Button>
             <Button
               variant={"outline"}
-              className="w-full rounded-full"
+              className="w-full rounded-none"
               onClick={props.setIsOpenDialog}
             >
               {t("dialog.cancel")}

--- a/app/(protected)/portfolio/new/media.component.tsx
+++ b/app/(protected)/portfolio/new/media.component.tsx
@@ -13,7 +13,7 @@ interface MediaShowProps {
 const MediaShow = (props: MediaShowProps) => {
   return (
     <div className='w-full relative'>
-      <Button variant='secondary' className='absolute top-2 right-2 rounded-full' onClick={props.removeFile}>
+      <Button variant='secondary' className='absolute top-2 right-2 rounded-none' onClick={props.removeFile}>
         <Trash2Icon className='w-4 h-4' />
       </Button>
       {
@@ -24,7 +24,7 @@ const MediaShow = (props: MediaShowProps) => {
       }
       {
         !props.isThumbnail ?
-          <Button variant='secondary' className='absolute bottom-2 right-2 rounded-full' onClick={props.setThumbnail}>
+          <Button variant='secondary' className='absolute bottom-2 right-2 rounded-none' onClick={props.setThumbnail}>
             Set as thumbnail
           </Button> : null
       }

--- a/app/(protected)/portfolio/new/media_upload.component.tsx
+++ b/app/(protected)/portfolio/new/media_upload.component.tsx
@@ -32,7 +32,7 @@ export function MediaUploadComponent(props: MediaUploadComponentProps) {
     <div className='w-full mx-auto'>
       <div
         {...getRootProps()}
-        className={cn(`cursor-pointer rounded-md border-2 border-dashed p-8 text-center transition-colors flex items-center justify-center flex-col max-w-3xl mx-auto`,
+        className={cn(`cursor-pointer rounded-none border border-dashed p-8 text-center transition-colors flex items-center justify-center flex-col max-w-3xl mx-auto`,
           isDragActive ? "border-primary bg-primary/10" : "border-border")}
       >
         <input {...getInputProps()} />

--- a/app/(protected)/portfolio/new/portfolio_create_card.component.tsx
+++ b/app/(protected)/portfolio/new/portfolio_create_card.component.tsx
@@ -99,7 +99,7 @@ export default function PortfolioCreateCard(props: PortfolioCreateCardProps) {
   }
 
   return (
-    <Card className="container mb-4 max-h-full w-full grow justify-between gap-4 px-4 md:mx-auto lg:flex">
+    <Card className="container mb-4 max-h-full w-full grow justify-between gap-4 px-4 md:mx-auto lg:flex rounded-none">
       <div className="position-absolute grow">
         <CardHeader>
           <FormProvider {...artworkForm}>
@@ -156,7 +156,7 @@ export default function PortfolioCreateCard(props: PortfolioCreateCardProps) {
         <UploadInfo />
         <div className="flex w-full flex-col gap-2 pt-10">
           <Button
-            className="w-full rounded-full"
+            className="w-full rounded-none border"
             onClick={onSubmit}
             disabled={submitLoading}
           >
@@ -165,7 +165,7 @@ export default function PortfolioCreateCard(props: PortfolioCreateCardProps) {
               : t("form.submit.create")}
           </Button>
           <Button
-            className="w-full rounded-full underline"
+            className="w-full rounded-none underline"
             variant={"secondary"}
             onClick={() => {
               artworkForm.reset();
@@ -178,7 +178,7 @@ export default function PortfolioCreateCard(props: PortfolioCreateCardProps) {
       </CardFooter>
 
       {submitLoading && uploadProgress > 0 && (
-        <Dialog open={true} onOpenChange={() => {}}>
+        <Dialog open={true} onOpenChange={() => { }}>
           <DialogContent className="sm:max-w-[425px]">
             <DialogHeader>
               <DialogTitle className="mb-2 text-2xl font-bold">

--- a/app/(protected)/profile/contacts/page.tsx
+++ b/app/(protected)/profile/contacts/page.tsx
@@ -1,0 +1,111 @@
+// File: app/(protected)/profile/contacts/page.tsx
+
+// API helpers
+import { fetchUserData } from "@/app/api/user/helper";
+
+// UI components
+import { ContactList } from "@/components/contacts/ContactList";
+import { ErrorContactCard } from "@/components/contacts/ErrorContactCard";
+import { ContactListSkeleton } from "@/components/contacts/ContactListSkeleton";
+import { ProfileCard } from "@/components/profile/ProfileCard";
+import { ProfileCardSkeleton } from "@/components/profile/ProfileCardSkeleton";
+import ErrorBoundary from "@/components/wrappers/ErrorBoundary";
+import { BackgroundDiv } from "@/components/wrappers/BackgroundDiv";
+import { Header } from "@/components/Header";
+
+// Hooks & utils
+import { getServerAuth } from "@/hooks/useServerAuth";
+import { getServerTranslation } from "@/lib/i18n/init-server";
+import { cn } from "@/lib/utils";
+import { cookies } from "next/headers";
+import { Suspense } from "react";
+import AnonymousProfilePage from "../AnonymousProfilePage";
+import { fetchUserPortfolioArtworksWithDetails } from "@/app/api/user/[id]/portfolio-artworks/helper";
+import { ErrorProfileCard } from "../ErrorProfileCard";
+
+export const dynamic = "force-dynamic";
+
+interface ContactsPageProps {
+    searchParams: {
+        lang?: string;
+    };
+}
+
+export default async function ProfileContactsPage({
+    searchParams,
+}: ContactsPageProps) {
+    const lang = searchParams?.lang || "en";
+    const { t } = await getServerTranslation(lang, [
+        "HomePage",
+        "ProfilePage",
+        "ContactList",
+    ]);
+    const { user, isLoggedIn, isAnonymous } = await getServerAuth();
+
+    // Redirect anonymous / unauthenticated users
+    if (!isLoggedIn || !user?.id || isAnonymous) {
+        return (
+            <AnonymousProfilePage
+                lang={lang}
+                isLoggedIn={isLoggedIn}
+                errorMessage={(await cookies()).get("error_message")?.value}
+            />
+        );
+    }
+
+    const userData = await fetchUserData(user.id);
+    const portfolioArtworksPromise = fetchUserPortfolioArtworksWithDetails(
+        user.id,
+    );
+
+    return (
+        <BackgroundDiv>
+            <div className="flex min-h-screen w-full flex-col">
+                <Header t={t} className="bg-background/80 backdrop-blur-xs" />
+                <main className="mt-10 w-full grow justify-between lg:mt-20 pb-16 lg:pb-0">
+                    <div className="w-full px-4 sm:px-8 md:px-16">
+                        <div className="flex flex-col lg:flex-row">
+                            {/* Contacts on the left */}
+                            <div
+                                className={cn(
+                                    "w-full order-2 lg:order-1 lg:w-2/3 2xl:w-3/4 -mt-px lg:mt-0",
+                                    "lg:h-[calc(100vh-225px)] lg:overflow-y-auto",
+                                )}
+                            >
+                                <ErrorBoundary fallback={<ErrorContactCard lang={lang} />}>
+                                    <Suspense fallback={<ContactListSkeleton />}>
+                                        <div className="grid grid-cols-2 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 2xl:grid-cols-4">
+                                            <ContactList userId={user.id} lang={lang} />
+                                        </div>
+                                    </Suspense>
+                                </ErrorBoundary>
+                            </div>
+
+                            {/* Profile card on the right */}
+                            <div
+                                className={cn(
+                                    "w-full order-1 lg:order-2 lg:w-1/3 2xl:w-1/4 lg:-ml-px",
+                                    "lg:max-h-[calc(100vh-225px)] lg:overflow-y-scroll no-scrollbar",
+                                    "-mt-px lg:mt-0",
+                                )}
+                            >
+                                <Suspense fallback={<ProfileCardSkeleton />}>
+                                    {userData ? (
+                                        <ProfileCard
+                                            showButtons={true}
+                                            userData={userData}
+                                            portfolioArtworksPromise={portfolioArtworksPromise}
+                                            lang={lang}
+                                        />
+                                    ) : (
+                                        <ErrorProfileCard lang={lang} />
+                                    )}
+                                </Suspense>
+                            </div>
+                        </div>
+                    </div>
+                </main>
+            </div>
+        </BackgroundDiv>
+    );
+} 

--- a/app/(protected)/profile/contacts/page.tsx
+++ b/app/(protected)/profile/contacts/page.tsx
@@ -26,15 +26,16 @@ import { ErrorProfileCard } from "../ErrorProfileCard";
 export const dynamic = "force-dynamic";
 
 interface ContactsPageProps {
-    searchParams: {
+    searchParams: Promise<{
         lang?: string;
-    };
+    }>;
 }
 
 export default async function ProfileContactsPage({
     searchParams,
 }: ContactsPageProps) {
-    const lang = searchParams?.lang || "en";
+    const params = await searchParams;
+    const lang = params?.lang || "en";
     const { t } = await getServerTranslation(lang, [
         "HomePage",
         "ProfilePage",

--- a/app/(protected)/profile/page.tsx
+++ b/app/(protected)/profile/page.tsx
@@ -6,7 +6,6 @@ import { fetchUserData } from "@/app/api/user/helper";
 
 // UI imports
 import { ProfileCard } from "@/components/profile/ProfileCard";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 // Wrapper imports
 import { BackgroundDiv } from "@/components/wrappers/BackgroundDiv";
@@ -21,16 +20,12 @@ import { cookies } from "next/headers";
 // Next.js imports
 import { Suspense } from "react";
 // Local component import
-import { ContactList } from "@/components/contacts/ContactList";
-import { ErrorContactCard } from "@/components/contacts/ErrorContactCard";
 import { ProfileCardSkeleton } from "@/components/profile/ProfileCardSkeleton";
 import ErrorBoundary from "@/components/wrappers/ErrorBoundary";
 import AnonymousProfilePage from "./AnonymousProfilePage";
 import { ErrorPortfolioProjectCard } from "./ErrorPortfolioProjectCard";
 import { ErrorProfileCard } from "./ErrorProfileCard";
 import PortfolioSection from "./PortfolioSection";
-import { ContactListSkeleton } from "@/components/contacts/ContactListSkeleton";
-import { use } from "react";
 
 interface ProfilePageProps {
   params: Promise<{}>;
@@ -74,57 +69,29 @@ export default async function ProfilePage(props: ProfilePageProps) {
         <main className="mt-10 w-full grow justify-between lg:mt-20">
           <div className="w-full px-4 sm:px-8 md:px-16">
             <div className="flex flex-col lg:flex-row">
-              <div className="w-full overflow-y-auto pr-0 lg:w-2/3 lg:pr-6">
-                <div className="mb-6">
-                  <Tabs defaultValue="contacts">
-                    <TabsList>
-                      <TabsTrigger value="contacts">
-                        {t("contactsHeader")}
-                      </TabsTrigger>
-                      <TabsTrigger value="portfolio">
-                        {t("portfolioHeader")}
-                      </TabsTrigger>
-                    </TabsList>
-                    <TabsContent value="contacts">
-                      {!user || !user.id ? (
-                        <ErrorContactCard
-                          lang={lang}
-                          message={t("noUserError", { ns: "ContactList" })}
-                        />
-                      ) : (
-                        <ErrorBoundary
-                          fallback={<ErrorContactCard lang={lang} />}
-                        >
-                          <Suspense fallback={<ContactListSkeleton />}>
-                            <div className="grid grid-cols-2 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 2xl:grid-cols-4">
-                              <ContactList userId={user.id} lang={lang} />
-                            </div>
-                          </Suspense>
-                        </ErrorBoundary>
-                      )}
-                    </TabsContent>
-
-                    <TabsContent value="portfolio">
-                      <ErrorBoundary
-                        fallback={<ErrorPortfolioProjectCard lang={lang} />}
-                      >
-                        <PortfolioSection
-                          showButtons={true}
-                          userData={userData}
-                          portfolioArtworksPromise={portfolioArtworksPromise}
-                          lang={lang}
-                        />
-                      </ErrorBoundary>
-                    </TabsContent>
-                  </Tabs>
-                </div>
+              <div
+                className={cn(
+                  "w-full order-2 lg:order-1 lg:w-2/3 2xl:w-3/4 -mt-px lg:mt-0",
+                  "lg:h-[calc(100vh-225px)] lg:flex lg:flex-col",
+                )}
+              >
+                <ErrorBoundary
+                  fallback={<ErrorPortfolioProjectCard lang={lang} />}
+                >
+                  <PortfolioSection
+                    showButtons={true}
+                    userData={userData}
+                    portfolioArtworksPromise={portfolioArtworksPromise}
+                    lang={lang}
+                  />
+                </ErrorBoundary>
               </div>
 
               <div
                 className={cn(
-                  "mt-6 w-full lg:w-[437px] lg:flex-shrink-0",
-                  "max-h-[calc(100vh-225px)] overflow-y-scroll",
-                  "lg:mt-0 lg:-ml-px lg:pl-6",
+                  "w-full order-1 lg:order-2 lg:w-1/3 2xl:w-1/4 lg:-ml-px",
+                  "lg:max-h-[calc(100vh-225px)] lg:overflow-y-scroll no-scrollbar",
+                  "-mt-px lg:mt-0",
                 )}
               >
                 <Suspense fallback={<ProfileCardSkeleton />}>

--- a/app/(public)/(event)/register/_sections/actions.ts
+++ b/app/(public)/(event)/register/_sections/actions.ts
@@ -224,7 +224,7 @@ export async function createRegistration(
             email: formData.email,
             name: `${formData.lastName} ${formData.firstName}`,
             phone_country_code: formData.phoneCountryCode,
-            phone_number: formData.phoneNumber,
+            phone_number: formData.phoneNumber ?? null,
             phone_country_alpha3: formData.phoneCountryAlpha3,
             status: status,
           })
@@ -250,7 +250,7 @@ export async function createRegistration(
             email: formData.email,
             name: name,
             phone_country_code: formData.phoneCountryCode,
-            phone_number: formData.phoneNumber, 
+            phone_number: formData.phoneNumber ?? null,
             phone_country_alpha3: formData.phoneCountryAlpha3,
             created_by: formData.created_by,
             status: status,

--- a/app/(public)/(event)/register/_sections/types.ts
+++ b/app/(public)/(event)/register/_sections/types.ts
@@ -13,7 +13,7 @@ export type FormData = {
   firstName: string;
   lastName: string;
   phoneCountryCode: string;
-  phoneNumber: string;
+  phoneNumber?: string | null;
   phoneCountryAlpha3: string;
 
   // Professional Info

--- a/app/actions/email/eventDetails.ts
+++ b/app/actions/email/eventDetails.ts
@@ -34,7 +34,10 @@ export async function sendEventDetailsEmail(
     const component: React.ReactNode = React.createElement(EventDetailsEmail, {
       name: registration.name,
       email: registration.email,
-      phone: `${registration.phone_country_code}${registration.phone_number}`,
+      phone:
+        registration.phone_number
+          ? `${registration.phone_country_code}${registration.phone_number}`
+          : "N/A",
       eventDate: dateStr,
       eventTime: `${timeStartStr} - ${timeEndStr}`,
       qrCodeUrl: qrCodeUrl,

--- a/app/actions/user/writeUserInfo.ts
+++ b/app/actions/user/writeUserInfo.ts
@@ -14,7 +14,7 @@ export async function writeUserInfo(
   userId: string,
   userInfo: {
     phoneCountryCode: string;
-    phoneNumber: string;
+    phoneNumber?: string;
     phoneCountryAlpha3: string;
     firstName: string;
     lastName: string;
@@ -50,7 +50,7 @@ export async function writeUserInfo(
 
   // Validate user info
   if (validateUserInfo) {
-    if (!userInfo.phoneNumber || !userInfo.firstName || !userInfo.lastName) {
+    if (!userInfo.firstName || !userInfo.lastName) {
       console.error("Invalid user info:", userInfo);
       return { success: false, error: "Invalid user info" };
     }

--- a/app/form-schemas/contact-info.ts
+++ b/app/form-schemas/contact-info.ts
@@ -7,9 +7,15 @@ export const contactInfoSchema = z.object({
   userName: z.string().optional(),
   displayName: z.string().optional(),
   phoneCountryCode: z.string().default("84"),
-  phoneNumber: z.string().refine((value) => /^\d{10}$/.test(value), {
-    message: "Phone number must be 10 digits",
-  }),
+  phoneNumber: z
+    .string()
+    .optional()
+    .refine(
+      (value) => value === undefined || value === "" || /^\d{10}$/.test(value),
+      {
+        message: "Phone number must be 10 digits",
+      },
+    ),
   phoneCountryAlpha3: z.string().default("VNM"),
   location: z.string().optional(),
   instagramHandle: z.string().optional(),

--- a/app/form-schemas/contact-info.ts
+++ b/app/form-schemas/contact-info.ts
@@ -9,13 +9,13 @@ export const contactInfoSchema = z.object({
   phoneCountryCode: z.string().default("84"),
   phoneNumber: z
     .string()
-    .optional()
     .refine(
       (value) => value === undefined || value === "" || /^\d{10}$/.test(value),
       {
         message: "Phone number must be 10 digits",
       },
-    ),
+    )
+    .optional(),
   phoneCountryAlpha3: z.string().default("VNM"),
   location: z.string().optional(),
   instagramHandle: z.string().optional(),

--- a/app/staff/api/checkin/route.ts
+++ b/app/staff/api/checkin/route.ts
@@ -51,7 +51,9 @@ export const POST = async (request: Request) => {
       id: result.data.id,
       name: result.data.name,
       email: result.data.email,
-      phone: `${result.data.phone_country_code}${result.data.phone_number}`,
+      phone: result.data.phone_number
+        ? `${result.data.phone_country_code}${result.data.phone_number}`
+        : undefined,
     });
   } catch (error) {
     console.error("Unexpected error during check-in:", error);

--- a/app/staff/api/search-id/route.ts
+++ b/app/staff/api/search-id/route.ts
@@ -39,7 +39,7 @@ interface SearchResponse {
   name: string;
   email: string;
   phone_country_code: string;
-  phone_number: string;
+  phone_number: string | null;
   phone_country_alpha3: string;
 }
 

--- a/app/types/EventRegistration.tsx
+++ b/app/types/EventRegistration.tsx
@@ -15,7 +15,7 @@ export interface EventRegistration {
   name: string;
   email: string;
   phone_country_code: string;
-  phone_number: string;
+  phone_number: string | null;
   phone_country_alpha3: string;
 }
 

--- a/components/auth/MagicSignIn.tsx
+++ b/components/auth/MagicSignIn.tsx
@@ -56,8 +56,8 @@ export function MagicSignIn({ purpose }: MagicSignInProps) {
 
   return (
     <>
-      <div className='flex flex-col gap-2 bg-primary/10 p-4 mb-2'>
-        <h1 className='text-2xl font-semibold text-primary'>{t(`title`)}</h1>
+      <div className="flex flex-col gap-2 bg-sunglow/10 p-4 mb-2 rounded-md border border-sunglow/40">
+        <h1 className="text-2xl font-semibold">{t(`title`)}</h1>
         <p>{t(`${purpose}.description`)}</p>
       </div>
       {magicLinkSent ? (
@@ -75,9 +75,14 @@ export function MagicSignIn({ purpose }: MagicSignInProps) {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
+              className="focus-visible:ring-sunglow focus-visible:ring-offset-2"
             />
           </div>
-          <Button type="submit" disabled={isLoading} className='w-full'>
+          <Button
+            type="submit"
+            disabled={isLoading}
+            className="w-full bg-sunglow text-black hover:bg-yellow-400 focus-visible:ring-yellow-500"
+          >
             {isLoading ? t(`sending`) : t(`send`)}
           </Button>
         </form>

--- a/components/profile/ProfileCard.tsx
+++ b/components/profile/ProfileCard.tsx
@@ -183,14 +183,17 @@ export function ProfileCard({
 
       {/* Edit Button */}
       {showButtons && (
-        <div className="px-6 py-4 border-t border-[#1A1A1A]">
-          <Button variant="outline" size="sm" asChild className="w-full">
-            <a href="/profile/edit">
-              <Pencil className="mr-1 h-4 w-4" />
-              {t("edit")}
-            </a>
-          </Button>
-        </div>
+        <Button
+          asChild
+          variant="ghost"
+          aria-label={t("edit")}
+          className="w-full rounded-none border-t border-[#1A1A1A] bg-[#FCFAF5] hover:bg-sunglow text-[#1A1A1A] hover:text-[#1A1A1A] font-sans font-extrabold text-base leading-[1.26] tracking-[0.02em] uppercase flex items-center justify-center py-4 px-6"
+        >
+          <a href="/profile/edit" className="flex items-center gap-2 w-full h-full justify-center">
+            <Pencil className="h-5 w-5" />
+            {t("edit")}
+          </a>
+        </Button>
       )}
     </div>
   );

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -5,10 +5,16 @@ import * as ProgressPrimitive from "@radix-ui/react-progress"
 
 import { cn } from "@/lib/utils"
 
+interface ProgressProps
+  extends React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> {
+  /** Override the indicator colour with a Tailwind class, e.g. "bg-sunglow" */
+  indicatorClassName?: string
+}
+
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
+  ProgressProps
+>(({ className, value, indicatorClassName, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
@@ -18,7 +24,10 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className={cn(
+        "h-full w-full flex-1 transition-all",
+        indicatorClassName ?? "bg-primary"
+      )}
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>

--- a/drizzle/schema/event.ts
+++ b/drizzle/schema/event.ts
@@ -72,7 +72,7 @@ export const eventRegistrations = pgTable("event_registrations", {
   name: text("name").notNull(),
   email: text("email").notNull(),
   phone_country_code: text("phone_country_code").notNull().default("84"),
-  phone_number: text("phone_number").notNull(),
+  phone_number: text("phone_number"),
   phone_country_alpha3: text("phone_country_alpha3").notNull().default("VNM"),
 }, (table) => ({
   uniqueUserSlotRegistration: unique("unique_user_slot_registration").on(

--- a/lib/checkin.ts
+++ b/lib/checkin.ts
@@ -21,7 +21,7 @@ export type CheckinResult = {
     name: string;
     email: string;
     phone_country_code: string;
-    phone_number: string;
+    phone_number: string | null;
     phone_country_alpha3: string;
   };
   error?: string;

--- a/public/translations/en/ContactInfoStep.json
+++ b/public/translations/en/ContactInfoStep.json
@@ -13,7 +13,7 @@
       "placeholder": "Doe"
     },
     "phone": {
-      "label": "Phone",
+      "label": "Phone (optional)",
       "placeholder": "1234567890"
     },
     "instagramHandle": {

--- a/public/translations/vi/ContactInfoStep.json
+++ b/public/translations/vi/ContactInfoStep.json
@@ -13,7 +13,7 @@
       "placeholder": "Nguyễn"
     },
     "phone": {
-      "label": "Số điện thoại",
+      "label": "Số điện thoại (tùy chọn)",
       "placeholder": "1234567890"
     },
     "instagramHandle": {


### PR DESCRIPTION
- Switch buttons/cards to square borders & sunglow accent for unified look
- Revamp Login & Signup layouts with hero banner and brand heading
- Add /profile/contacts route; move contact list there
- Update Profile page layout, portfolio edit/delete/add actions
- Add indicatorClassName prop to Progress component
- Make phoneNumber optional in schema; update EN/VI translations
- Fix typo “Co-owner”; tidy imports


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated contacts page in the profile section with a two-column layout, displaying contacts and profile information side by side.

* **Refactor**
  * Login and signup pages redesigned with responsive two-column layouts, improved branding, and enhanced mobile experience.
  * Portfolio and profile pages updated for improved layout, removing tabs and centralizing project edit/delete controls for better usability.

* **Style**
  * Updated buttons, cards, and form elements across multiple pages to use square corners and enhanced border styles for a more consistent look.
  * Improved visual styling of magic sign-in and profile edit button for better accessibility and appearance.

* **Bug Fixes**
  * Corrected a typo in the "Add Co-owner" dialog heading.

* **Documentation**
  * Updated English and Vietnamese translations to indicate the phone number field is optional.

* **New Features**
  * Progress bar component now supports customizable indicator colors via Tailwind CSS classes.

* **Other**
  * Phone number field in contact info is now optional and validated only if provided.
  * Phone number handling improved across event registration, check-in, and user info processes to allow optional or null values and prevent invalid data display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->